### PR TITLE
Fix bad AccessToken expiration check in StateManager and add tests

### DIFF
--- a/Okta.Xamarin/Okta.Xamarin.Test/OidcClientShould.cs
+++ b/Okta.Xamarin/Okta.Xamarin.Test/OidcClientShould.cs
@@ -130,6 +130,24 @@ namespace Okta.Xamarin.Test
 			StateManager state = await client.SignInWithBrowserAsync();
 
 			Assert.Equal("access_token_example", state.AccessToken);
+
+			Assert.True(state.IsAuthenticated);
+		}
+
+		[Fact]
+		public void CorrectlySetIsAuthenticated()
+		{
+			StateManager stateWithNoToken = new StateManager(null, "test");
+			Assert.False(stateWithNoToken.IsAuthenticated);
+
+			StateManager stateWithTokenAndExpInPast = new StateManager("test", "test", null, null, -100);
+			Assert.False(stateWithTokenAndExpInPast.IsAuthenticated);
+
+			StateManager stateWithNoExp = new StateManager("test", "test");
+			Assert.True(stateWithNoExp.IsAuthenticated);
+
+			StateManager stateWithExpInFuture = new StateManager("test", "test", null, null, 100);
+			Assert.True(stateWithExpInFuture.IsAuthenticated);
 		}
 
 		[Fact]

--- a/Okta.Xamarin/Okta.Xamarin/StateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/StateManager.cs
@@ -43,7 +43,11 @@ namespace Okta.Xamarin
 		/// </summary>
 		public bool IsAuthenticated
 		{
-			get { return (!string.IsNullOrEmpty(AccessToken) && Expires < DateTime.UtcNow); }
+			get
+			{
+				return (!string.IsNullOrEmpty(AccessToken) &&  // there is an access token
+								Expires > DateTime.UtcNow);    // and it's not yet expired
+			}
 		}
 
 


### PR DESCRIPTION
Laura noticed that `StateManager.IsAuthenticated` was giving an incorrect result.  This was due to comparing the expiration time and the current time incorrectly.  This PR fixes that and adds tests to confirm the correct behavior.