### PR TITLE
OKTA-381425: check state manager for null on sign out

### DIFF
--- a/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
@@ -99,9 +99,9 @@ namespace Okta.Xamarin
         {
             validator.Validate(this.Config);
             this.currentTask = new TaskCompletionSource<IOktaStateManager>();
-            if (!stateManager.IsAuthenticated)
+            if (stateManager == null || stateManager.IsAuthenticated == false)
             {
-                this.currentTask.SetResult(stateManager);
+                this.currentTask.SetResult(stateManager ?? new OktaStateManager());
                 return this.currentTask.Task;
             }
 


### PR DESCRIPTION
- Fix NullReferenceException on 'Sign out' click before being signed in, in demo app.