### PR TITLE
OKTA-363613: add secure storage implementation and related tests

### DIFF
--- a/Okta.Xamarin/Okta.Xamarin.Android/Okta.Xamarin.Android.csproj
+++ b/Okta.Xamarin/Okta.Xamarin.Android/Okta.Xamarin.Android.csproj
@@ -39,11 +39,14 @@
     <BundleAssemblies>false</BundleAssemblies>
     <AndroidKeyStore>true</AndroidKeyStore>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
-    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
+    <EmbedAssembliesIntoApk>false</EmbedAssembliesIntoApk>
     <AndroidSigningKeyStore>.\Keystore\okta.xamarin.android-test\okta.xamarin.android-test.keystore</AndroidSigningKeyStore>
     <AndroidSigningKeyAlias>okta.xamarin.android-test</AndroidSigningKeyAlias>
     <AndroidSigningKeyPass>okta.xamarin.android-test</AndroidSigningKeyPass>
     <AndroidSigningStorePass>okta.xamarin.android-test</AndroidSigningStorePass>
+    <AndroidSupportedAbis>
+    </AndroidSupportedAbis>
+    <AndroidCreatePackagePerAbi>true</AndroidCreatePackagePerAbi>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Okta.Xamarin/Okta.Xamarin.Android/OktaLoginCallbackInterceptorActivity.cs
+++ b/Okta.Xamarin/Okta.Xamarin.Android/OktaLoginCallbackInterceptorActivity.cs
@@ -14,7 +14,7 @@ namespace Okta.Xamarin.Android
 	[Activity(Label = "OktaCallbackInterceptorActivity", NoHistory = true, LaunchMode = LaunchMode.SingleInstance)]
 	public class OktaLoginCallbackInterceptorActivity<TMain> : Activity
 	{
-		protected override async void OnCreate(Bundle savedInstanceState)
+		protected override void OnCreate(Bundle savedInstanceState)
 		{
 			base.OnCreate(savedInstanceState);
 			global::Android.Net.Uri uri_android = Intent.Data;

--- a/Okta.Xamarin/Okta.Xamarin.Android/OktaMainActivity.cs
+++ b/Okta.Xamarin/Okta.Xamarin.Android/OktaMainActivity.cs
@@ -8,22 +8,37 @@ using Android.App;
 using Android.Content.PM;
 using Android.Runtime;
 using Android.OS;
+using Okta.Xamarin.TinyIoC;
 
 namespace Okta.Xamarin.Android
 {
 	[Activity(Label = "Okta.Xamarin")]
 	public class OktaMainActivity<TApp> : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity where TApp : global::Xamarin.Forms.Application, new()
 	{
+		public OktaMainActivity()
+		{
+			OktaContainer = new TinyIoCContainer();
+		}
+
 		protected override void OnCreate(Bundle savedInstanceState)
 		{
-			OktaContext.Init(new AndroidOidcClient(this, AndroidOktaConfig.LoadFromXmlStream(Assets.Open("OktaConfig.xml"))));
-			OktaContext.Current.SignInCompleted += OnSignInCompleted;
-			OktaContext.Current.SignOutCompleted += OnSignOutCompleted;
+			OktaContext.Current.SignInCompleted += HandleSignInCompleted;
+			OktaContext.Current.SignOutCompleted += HandleSignOutCompleted;
+
+			IOktaConfig oktaConfig = AndroidOktaConfig.LoadFromXmlStream(Assets.Open("OktaConfig.xml"));
+			OktaContext.RegisterOktaDefaults(OktaContainer);
+			OktaContainer.Register(oktaConfig);
+			OktaContainer.Register<IOidcClient>(new AndroidOidcClient(this, oktaConfig));
+
+			RegisterOktaServices(); // ensures that consumer provided services are registered by calling overridable RegisterOktaServices method
+
+			OktaContext.Current.InitServices(OktaContainer);
 
 			base.OnCreate(savedInstanceState);
-
+			
 			global::Xamarin.Essentials.Platform.Init(this, savedInstanceState);
 			global::Xamarin.Forms.Forms.Init(this, savedInstanceState);
+
 			LoadApplication(new TApp());
 		}
 
@@ -34,14 +49,52 @@ namespace Okta.Xamarin.Android
 			base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
 		}
 
-		public virtual void OnSignInCompleted(object sender, SignInEventArgs signInEventArgs)
+		private void HandleSignInCompleted(object sender, SignInEventArgs signInEventArgs)
 		{
-
+			// future Okta specific updates go here
+			this.OnSignInCompleted(sender, signInEventArgs);
 		}
 
+		/// <summary>
+		/// Override this method if you wish to execute custom code when sign in completes.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="signInEventArgs"></param>
+		public virtual void OnSignInCompleted(object sender, SignInEventArgs signInEventArgs)
+		{
+			// extenders may override this method to execute code when sign in completes
+		}
+
+		private void HandleSignOutCompleted(object sender, SignOutEventArgs signOutEventArgs)
+		{
+			// future Okta specific updates go here
+			this.OnSignOutCompleted(sender, signOutEventArgs);
+		}
+
+		/// <summary>
+		/// Override this method if you wish to execute custom code when sign out completes.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="signOutEventArgs"></param>
 		public virtual void OnSignOutCompleted(object sender, SignOutEventArgs signOutEventArgs)
 		{
+			// extenders may override this method to execute code when sign out completes.
+		}
 
+		protected TinyIoCContainer OktaContainer { get; }
+
+		private void RegisterOktaServices()
+		{
+			RegisterOktaServices(OktaContainer);
+		}
+
+		/// <summary>
+		/// Override this mehod if you wish to modify the content of the inversion of control container.
+		/// </summary>
+		/// <param name="iocContainer"></param>
+		protected virtual void RegisterOktaServices(TinyIoCContainer iocContainer)
+		{
+			// extenders may override this method to register their services with the IoCContainer
 		}
 	}
 }

--- a/Okta.Xamarin/Okta.Xamarin.Android/OktaMainActivity.cs
+++ b/Okta.Xamarin/Okta.Xamarin.Android/OktaMainActivity.cs
@@ -81,6 +81,9 @@ namespace Okta.Xamarin.Android
 			// extenders may override this method to execute code when sign out completes.
 		}
 
+		/// <summary>
+		/// Gets the inversion of control container.
+		/// </summary>
 		protected TinyIoCContainer OktaContainer { get; }
 
 		private void RegisterOktaServices()

--- a/Okta.Xamarin/Okta.Xamarin.iOS/OktaAppDelegate.cs
+++ b/Okta.Xamarin/Okta.Xamarin.iOS/OktaAppDelegate.cs
@@ -63,35 +63,66 @@ namespace Okta.Xamarin.iOS
 		// OktaAppDelegate, the call to base.FinishedLaunching results in the Forms.SetFlags and Forms.Init 
 		// methods being called twice; this causes an exception to be thrown.
 
+		/// <summary>
+		/// Executes code in response to the sign in completed event.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="signInEventArgs"></param>
 		protected void HandleSignInCompleted(object sender, SignInEventArgs signInEventArgs)
 		{
 			// future Okta specific updates go here
 			this.OnSignInCompleted(sender, signInEventArgs);
 		}
 
+		/// <summary>
+		/// A virtual method to be overridden by consumers to execute code when sign in completes.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="signInEventArgs"></param>
 		public virtual void OnSignInCompleted(object sender, SignInEventArgs signInEventArgs)
 		{
 			// extenders may override this method to execute code when sign in completes
 		}
 
+		/// <summary>
+		/// Executes code in response to the sign out completed event.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="signOutEventArgs"></param>
 		protected void HandleSignOutCompleted(object sender, SignOutEventArgs signOutEventArgs)
 		{
 			// future Okta specific updates go here
 			this.OnSignOutCompleted(sender, signOutEventArgs);
 		}
 
+		/// <summary>
+		/// A virtual method to be overridden by consumers to execute code when sign out completes.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="signOutEventArgs"></param>
 		public virtual void OnSignOutCompleted(object sender, SignOutEventArgs signOutEventArgs)
 		{
 			// extenders may override this method to execute code when sign out completes.
 		}
 
+		/// <summary>
+		/// Gets the Okta inversion of control container.
+		/// </summary>
 		protected TinyIoCContainer OktaContainer { get; }
 
+		/// <summary>
+		/// Registers Okta services with the inversion of control container.
+		/// </summary>
 		protected void RegisterOktaServices()
 		{
 			RegisterOktaServices(OktaContainer);
 		}
 
+		/// <summary>
+		/// A virtual method to be overridden by consumers to examine, interact with and change the 
+		/// inversion of control container.
+		/// </summary>
+		/// <param name="iocContainer">The inversion of control container.</param>
 		protected virtual void RegisterOktaServices(TinyIoCContainer iocContainer)
 		{
 			// extenders may override this method to register their services with the IoCContainer
@@ -136,35 +167,66 @@ namespace Okta.Xamarin.iOS
 			return iOsOidcClient.IsOktaCallback(application, url, sourceApplication, annotation);
 		}
 
+		/// <summary>
+		/// Executes code in response to the sign in completed event.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="signInEventArgs"></param>
 		protected void HandleSignInCompleted(object sender, SignInEventArgs signInEventArgs)
 		{
 			// future Okta specific updates go here
 			this.OnSignInCompleted(sender, signInEventArgs);
 		}
 
+		/// <summary>
+		/// A virtual method to be overridden by consumers to execute code when sign in completes.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="signInEventArgs"></param>
 		public virtual void OnSignInCompleted(object sender, SignInEventArgs signInEventArgs)
 		{
 			// extenders may override this method to execute code when sign in completes
 		}
 
+		/// <summary>
+		/// Executes code in response to the sign out completed event.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="signOutEventArgs"></param>
 		protected void HandleSignOutCompleted(object sender, SignOutEventArgs signOutEventArgs)
 		{
 			// future Okta specific updates go here
 			this.OnSignOutCompleted(sender, signOutEventArgs);
 		}
 
+		/// <summary>
+		/// A virtual method to be overridden by consumers to execute code when sign out completes.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="signOutEventArgs"></param>
 		public virtual void OnSignOutCompleted(object sender, SignOutEventArgs signOutEventArgs)
 		{
 			// extenders may override this method to execute code when sign out completes.
 		}
 
+		/// <summary>
+		/// Gets the Okta inversion of control container.
+		/// </summary>
 		protected TinyIoCContainer OktaContainer { get; }
 
+		/// <summary>
+		/// Registers Okta services with the inversion of control container.
+		/// </summary>
 		protected void RegisterOktaServices()
 		{
 			RegisterOktaServices(OktaContainer);
 		}
 
+		/// <summary>
+		/// A virtual method to be overridden by consumers to examine, interact with and change the 
+		/// inversion of control container.
+		/// </summary>
+		/// <param name="iocContainer">The inversion of control container.</param>
 		protected virtual void RegisterOktaServices(TinyIoCContainer iocContainer)
 		{
 			// extenders may override this method to register their services with the IoCContainer

--- a/Okta.Xamarin/Okta.Xamarin.iOS/OktaAppDelegate.cs
+++ b/Okta.Xamarin/Okta.Xamarin.iOS/OktaAppDelegate.cs
@@ -6,24 +6,42 @@
 
 
 using Foundation;
+using Okta.Xamarin.Services;
+using Okta.Xamarin.TinyIoC;
 using UIKit;
 
 namespace Okta.Xamarin.iOS
 {
 	/// <summary>
-	/// Okta specific app delegate that loads an instance of the specified generic application type T and initializes OktaContext when finished launching.
+	/// Okta specific app delegate that loads an instance of the specified generic application type TApp and initializes OktaContext when finished launching.
 	/// </summary>
-	/// <typeparam name="T"></typeparam>
-	public class OktaAppDelegate<T> : global::Xamarin.Forms.Platform.iOS.FormsApplicationDelegate where T: global::Xamarin.Forms.Application, new()
+	/// <typeparam name="TApp"></typeparam>
+	public class OktaAppDelegate<TApp> : global::Xamarin.Forms.Platform.iOS.FormsApplicationDelegate where TApp: global::Xamarin.Forms.Application, new()
 	{
+		public OktaAppDelegate()
+		{
+			OktaContainer = new TinyIoCContainer();
+		}
+
 		public override bool FinishedLaunching(UIApplication app, NSDictionary options)
 		{
 			global::Xamarin.Forms.Forms.SetFlags("CollectionView_Experimental");
 			global::Xamarin.Forms.Forms.Init();
-			LoadApplication(new T());
+			LoadApplication(new TApp());
+
 			bool result = base.FinishedLaunching(app, options);
 
-			OktaContext.Init(new iOsOidcClient(Window.RootViewController, iOsOktaConfig.LoadFromPList("OktaConfig.plist")));
+			OktaContext.Current.SignInCompleted += HandleSignInCompleted;
+			OktaContext.Current.SignOutCompleted += HandleSignOutCompleted;
+
+			IOktaConfig oktaConfig = iOsOktaConfig.LoadFromPList("OktaConfig.plist");
+			OktaContext.RegisterOktaDefaults(OktaContainer);
+			OktaContainer.Register(oktaConfig);
+			OktaContainer.Register<IOidcClient>(new iOsOidcClient(Window.RootViewController, oktaConfig));
+
+			RegisterOktaServices(); // ensures that consumer provided services are registered by calling overridable RegisterOktaServices method
+
+			OktaContext.Current.InitServices(OktaContainer);
 
 			return result;
 		}
@@ -38,12 +56,53 @@ namespace Okta.Xamarin.iOS
 		{
 			return iOsOidcClient.IsOktaCallback(application, url, sourceApplication, annotation);
 		}
+
+		#region Duplicated code
+		// Due to Xamarin Forms requirement that LoadApplication MUST be called before FinishedLaunching
+		// the methods below are duplicated from the OktaAppDelegate class.  If OktaAppDelegate<TApp> extends
+		// OktaAppDelegate, the call to base.FinishedLaunching results in the Forms.SetFlags and Forms.Init 
+		// methods being called twice; this causes an exception to be thrown.
+
+		protected void HandleSignInCompleted(object sender, SignInEventArgs signInEventArgs)
+		{
+			// future Okta specific updates go here
+			this.OnSignInCompleted(sender, signInEventArgs);
+		}
+
+		public virtual void OnSignInCompleted(object sender, SignInEventArgs signInEventArgs)
+		{
+			// extenders may override this method to execute code when sign in completes
+		}
+
+		protected void HandleSignOutCompleted(object sender, SignOutEventArgs signOutEventArgs)
+		{
+			// future Okta specific updates go here
+			this.OnSignOutCompleted(sender, signOutEventArgs);
+		}
+
+		public virtual void OnSignOutCompleted(object sender, SignOutEventArgs signOutEventArgs)
+		{
+			// extenders may override this method to execute code when sign out completes.
+		}
+
+		protected TinyIoCContainer OktaContainer { get; }
+
+		protected void RegisterOktaServices()
+		{
+			RegisterOktaServices(OktaContainer);
+		}
+
+		protected virtual void RegisterOktaServices(TinyIoCContainer iocContainer)
+		{
+			// extenders may override this method to register their services with the IoCContainer
+		}
+		#endregion
 	}
 
 	/// <summary>
 	/// Okta specific app delegate that initializes OktaContext when finished launching.
 	/// </summary>
-	public class OktaAppDelegate: global::Xamarin.Forms.Platform.iOS.FormsApplicationDelegate
+	public class OktaAppDelegate: global::Xamarin.Forms.Platform.iOS.FormsApplicationDelegate // The use case is not clear for this class, should deprecate in a later release.  
 	{        
 		public override bool FinishedLaunching(UIApplication app, NSDictionary options)
 		{
@@ -52,7 +111,16 @@ namespace Okta.Xamarin.iOS
 
 			bool result = base.FinishedLaunching(app, options);
 
-			OktaContext.Init(new iOsOidcClient(Window.RootViewController, iOsOktaConfig.LoadFromPList("OktaConfig.plist")));
+			OktaContext.Current.SignInCompleted += HandleSignInCompleted;
+			OktaContext.Current.SignOutCompleted += HandleSignOutCompleted;
+
+			IOktaConfig oktaConfig = iOsOktaConfig.LoadFromPList("Oktaconfig.plist");
+			OktaContext.RegisterOktaDefaults(OktaContainer);
+			OktaContainer.Register(oktaConfig);
+			OktaContainer.Register<IOidcClient>(new iOsOidcClient(Window.RootViewController, oktaConfig));
+
+			RegisterOktaServices(); // ensures that consumer provided services are registered by calling overridable RegisterOktaServices method
+			OktaContext.Current.InitServices(OktaContainer);
 
 			return result;
 		}
@@ -66,6 +134,40 @@ namespace Okta.Xamarin.iOS
 		)
 		{
 			return iOsOidcClient.IsOktaCallback(application, url, sourceApplication, annotation);
+		}
+
+		protected void HandleSignInCompleted(object sender, SignInEventArgs signInEventArgs)
+		{
+			// future Okta specific updates go here
+			this.OnSignInCompleted(sender, signInEventArgs);
+		}
+
+		public virtual void OnSignInCompleted(object sender, SignInEventArgs signInEventArgs)
+		{
+			// extenders may override this method to execute code when sign in completes
+		}
+
+		protected void HandleSignOutCompleted(object sender, SignOutEventArgs signOutEventArgs)
+		{
+			// future Okta specific updates go here
+			this.OnSignOutCompleted(sender, signOutEventArgs);
+		}
+
+		public virtual void OnSignOutCompleted(object sender, SignOutEventArgs signOutEventArgs)
+		{
+			// extenders may override this method to execute code when sign out completes.
+		}
+
+		protected TinyIoCContainer OktaContainer { get; }
+
+		protected void RegisterOktaServices()
+		{
+			RegisterOktaServices(OktaContainer);
+		}
+
+		protected virtual void RegisterOktaServices(TinyIoCContainer iocContainer)
+		{
+			// extenders may override this method to register their services with the IoCContainer
 		}
 	}
 }

--- a/Okta.Xamarin/Okta.Xamarin.iOS/iOSOidcClient.cs
+++ b/Okta.Xamarin/Okta.Xamarin.iOS/iOSOidcClient.cs
@@ -64,7 +64,7 @@ namespace Okta.Xamarin.iOS
 
 
 		/// <summary>
-		/// This is used to handle the callback from the Safari view controller after a user logs in.  You need to forward calls to AppDelegate.OpenUrl to this function.  Please see the documentation for more information.
+		/// This is used to handle the callback from the Safari view controller after a user logs in.
 		/// </summary>
 		/// <returns><see langword="true"/> if this url can be handled by an <see cref="OidcClient"/>, or <see langword="false"/> if it is some other url which is not handled by the login flow.</returns>
 		public static bool IsOktaCallback(UIApplication application, NSUrl url, string sourceApplication, NSObject annotation)

--- a/Okta.Xamarin/Okta.Xamarin/IOktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/IOktaStateManager.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace Okta.Xamarin
 {
@@ -213,5 +214,12 @@ namespace Okta.Xamarin
         /// </summary>
         /// <returns>The current instance.</returns>
         Task<OktaStateManager> ClearSecureStorageStateAsync();
+
+        /// <summary>
+        /// Convert the current state manager instance to the json equivalent.
+        /// </summary>
+        /// <param name="formatting">The formatting.</param>
+        /// <returns>json string.</returns>
+        string ToJson(Formatting formatting = Formatting.Indented);
     }
 }

--- a/Okta.Xamarin/Okta.Xamarin/IOktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/IOktaStateManager.cs
@@ -17,6 +17,36 @@ namespace Okta.Xamarin
     public interface IOktaStateManager
     {
         /// <summary>
+        /// The event that is raised before writing to secure storage.
+        /// </summary>
+        event EventHandler<SecureStorageEventArgs> SecureStorageWriteStarted;
+
+        /// <summary>
+        /// The event that is raised when writing to secure storage completes.
+        /// </summary>
+        event EventHandler<SecureStorageEventArgs> SecureStorageWriteCompleted;
+
+        /// <summary>
+        /// The event that is raised when an exception occurs writing to secure storage.
+        /// </summary>
+        event EventHandler<SecureStorageExceptionEventArgs> SecureStorageWriteException;
+
+        /// <summary>
+        /// The event that is raised before reading from secure storage.
+        /// </summary>
+        event EventHandler<SecureStorageEventArgs> SecureStorageReadStarted;
+
+        /// <summary>
+        /// The event that is raised when reading from secure storage completes.
+        /// </summary>
+        event EventHandler<SecureStorageEventArgs> SecureStorageReadCompleted;
+
+        /// <summary>
+        /// The event that is raised when an exception occurs reading from secure storage.
+        /// </summary>
+        event EventHandler<SecureStorageExceptionEventArgs> SecureStorageReadException;
+
+        /// <summary>
         /// The event that is raised when an API exception occurs.
         /// </summary>
         event EventHandler<RequestExceptionEventArgs> RequestException;
@@ -138,17 +168,44 @@ namespace Okta.Xamarin
         Task RevokeAsync(TokenKind tokenKind);
 
         /// <summary>
-        /// Stores the tokens securely in platform-specific secure storage.  This is an async method and should be awaited.
+        /// Stores the tokens securely in platform-specific secure storage.
+        /// Subscribe to SecureStorageWriteException event for exception details
+        /// if an exception occurs, see event <see cref="SecureStorageWriteException"/>.
         /// </summary>
         /// <returns>Task which tracks the progress of the save.</returns>
         Task WriteToSecureStorageAsync();
 
         /// <summary>
-        /// Retrieves a stored state manager for a given config.  This is an async method and should be awaited.
+        /// Retrieves a stored state manager from secure storage if it exists.
+        /// Returns null if a state manager is not found in secure storage or
+        /// if an exception occurs.  In case of exception, subscribe to the
+        /// SecureStorageReadException event for exception details,
+        /// see event <see cref="SecureStorageReadException"/>.
         /// </summary>
-        /// <param name="config">the Okta configuration that corresponds to a manager you are interested in</param>
-        /// <returns>If a state manager is found for the provided config, this Task will return the <see cref="OktaStateManager"/>.</returns>
+        /// <returns><see cref="OktaStateManager"/>.</returns>
+        Task<OktaStateManager> ReadFromSecureStorageAsync();
+
+        /// <summary>
+        /// Retrieves a stored state manager from secure storage if it exists.
+        /// Returns null if a state manager is not found in secure storage or
+        /// if an exception occurs.  In case of exception, subscribe to the
+        /// SecureStorageReadException event for exception details,
+        /// see event <see cref="SecureStorageReadException"/>.
+        /// </summary>
+        /// <param name="config">The IOktaConfig implementation to apply to the resulting state manager.</param>
+        /// <returns><see cref="OktaStateManager"/>.</returns>
         Task<OktaStateManager> ReadFromSecureStorageAsync(IOktaConfig config);
 
+        /// <summary>
+        /// Retrieves a stored state manager from secure storage if it exists.
+        /// Returns null if a state manager is not found in secure storage or
+        /// if an exception occurs.  In case of exception, subscribe to the
+        /// SecureStorageReadException event for exception details,
+        /// see event <see cref="SecureStorageReadException"/>.
+        /// </summary>
+        /// <param name="config">The IOktaConfig implementation to apply to the resulting state manager.</param>
+        /// <param name="client">The IOidcClient implementation to apply to the resulting state manager.</param>
+        /// <returns><see cref="OktaStateManager"/>.</returns>
+        Task<OktaStateManager> ReadFromSecureStorageAsync(IOktaConfig config, IOidcClient client);
     }
 }

--- a/Okta.Xamarin/Okta.Xamarin/IOktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/IOktaStateManager.cs
@@ -207,5 +207,11 @@ namespace Okta.Xamarin
         /// <param name="client">The IOidcClient implementation to apply to the resulting state manager.</param>
         /// <returns><see cref="OktaStateManager"/>.</returns>
         Task<OktaStateManager> ReadFromSecureStorageAsync(IOktaConfig config, IOidcClient client);
+
+        /// <summary>
+        /// Calls Clear() then WriteToSecureStorageAsync, effectively writing a stateless state manager to secure storage.
+        /// </summary>
+        /// <returns>The current instance.</returns>
+        Task<OktaStateManager> ClearSecureStorageStateAsync();
     }
 }

--- a/Okta.Xamarin/Okta.Xamarin/InitServicesEventArgs.cs
+++ b/Okta.Xamarin/Okta.Xamarin/InitServicesEventArgs.cs
@@ -1,14 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// <copyright file="InitServicesEventArgs.cs" company="Okta, Inc">
+// Copyright (c) 2020 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
 using Okta.Xamarin.TinyIoC;
 
 namespace Okta.Xamarin
 {
+    /// <summary>
+    /// Represents arguments relevant to initializing services events.
+    /// </summary>
     public class InitServicesEventArgs : EventArgs
     {
+        /// <summary>
+        /// Gets or sets the inversion of control container.
+        /// </summary>
         public TinyIoCContainer TinyIoCContainer { get; set; }
 
+        /// <summary>
+        /// Gets or sets the exception if any, may be null.
+        /// </summary>
         public Exception Exception { get; set; }
     }
 }

--- a/Okta.Xamarin/Okta.Xamarin/InitServicesEventArgs.cs
+++ b/Okta.Xamarin/Okta.Xamarin/InitServicesEventArgs.cs
@@ -9,7 +9,7 @@ using Okta.Xamarin.TinyIoC;
 namespace Okta.Xamarin
 {
     /// <summary>
-    /// Represents arguments relevant to initializing services events.
+    /// Arguments relevant to events that occur during service initialization.
     /// </summary>
     public class InitServicesEventArgs : EventArgs
     {

--- a/Okta.Xamarin/Okta.Xamarin/InitServicesEventArgs.cs
+++ b/Okta.Xamarin/Okta.Xamarin/InitServicesEventArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Okta.Xamarin.TinyIoC;
+
+namespace Okta.Xamarin
+{
+    public class InitServicesEventArgs : EventArgs
+    {
+        public TinyIoCContainer TinyIoCContainer { get; set; }
+
+        public Exception Exception { get; set; }
+    }
+}

--- a/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
@@ -289,6 +289,25 @@ namespace Okta.Xamarin
         }
 
         /// <summary>
+        /// Clear state data from secure storage.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task ClearStateAsync()
+        {
+            await this.StateManager.ClearSecureStorageStateAsync();
+        }
+
+        /// <summary>
+        /// Clear state data from secure storage.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static async Task ClearStateAsync(OktaContext oktaContext = null)
+        {
+            oktaContext = oktaContext ?? Current;
+            await oktaContext.ClearStateAsync();
+        }
+
+        /// <summary>
         /// Get an instance of the specified generic type T from the underlying IoC container.
         /// </summary>
         /// <typeparam name="T">The type to return.</typeparam>

--- a/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
@@ -300,7 +300,7 @@ namespace Okta.Xamarin
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task ClearStateAsync()
         {
-            await this.StateManager.ClearSecureStorageStateAsync();
+            await this.StateManager?.ClearSecureStorageStateAsync();
         }
 
         /// <summary>

--- a/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
@@ -6,8 +6,9 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;
-using System.Text;
 using System.Threading.Tasks;
+using Okta.Xamarin.Services;
+using Okta.Xamarin.TinyIoC;
 
 namespace Okta.Xamarin
 {
@@ -19,6 +20,59 @@ namespace Okta.Xamarin
         private static Lazy<OktaContext> current = new Lazy<OktaContext>(() => new OktaContext());
         private IOktaStateManager stateManager;
         private OAuthException oAuthException;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OktaContext"/> class.
+        /// </summary>
+        public OktaContext()
+        {
+            this.IoCContainer = new TinyIoCContainer();
+        }
+
+        /// <summary>
+        /// The event that is raised when initialization of services is started.
+        /// </summary>
+        public event EventHandler<InitServicesEventArgs> InitServicesStarted;
+
+        /// <summary>
+        /// The event that is raised when initialization of services completes.
+        /// </summary>
+        public event EventHandler<InitServicesEventArgs> InitServicesCompleted;
+
+        /// <summary>
+        /// The event that is raised when an exception occurs during initialization of services.
+        /// </summary>
+        public event EventHandler<InitServicesEventArgs> InitServicesException;
+
+        /// <summary>
+        /// The event that is raised before writing to secure storage.
+        /// </summary>
+        public event EventHandler<SecureStorageEventArgs> SecureStorageWriteStarted;
+
+        /// <summary>
+        /// The event that is raised when writing to secure storage completes.
+        /// </summary>
+        public event EventHandler<SecureStorageEventArgs> SecureStorageWriteCompleted;
+
+        /// <summary>
+        /// The event that is raised when an exception occurrs writing to secure storage.
+        /// </summary>
+        public event EventHandler<SecureStorageExceptionEventArgs> SecureStorageWriteException;
+
+        /// <summary>
+        /// The event that is raised before reading from secure storage.
+        /// </summary>
+        public event EventHandler<SecureStorageEventArgs> SecureStorageReadStarted;
+
+        /// <summary>
+        /// The event that is raised when reading from secure storage completes.
+        /// </summary>
+        public event EventHandler<SecureStorageEventArgs> SecureStorageReadCompleted;
+
+        /// <summary>
+        /// The event that is raised when an exception occurrs reading from secure storage.
+        /// </summary>
+        public event EventHandler<SecureStorageExceptionEventArgs> SecureStorageReadException;
 
         /// <summary>
         /// The event that is raised when a non success status code is received from the API.
@@ -149,6 +203,11 @@ namespace Okta.Xamarin
         }
 
         /// <summary>
+        /// Gets or sets the secure key-value store.
+        /// </summary>
+        public SecureKeyValueStore SecureKeyValueStore { get; set; }
+
+        /// <summary>
         /// Gets or sets the default client.
         /// </summary>
         public IOidcClient OidcClient { get; set; }
@@ -170,8 +229,96 @@ namespace Okta.Xamarin
                 if (this.stateManager != null)
                 {
                     this.stateManager.RequestException += (sender, args) => this.RequestException?.Invoke(sender, args);
+                    this.stateManager.SecureStorageReadStarted += (sender, args) => this.SecureStorageReadStarted?.Invoke(sender, args);
+                    this.stateManager.SecureStorageReadCompleted += (sender, args) => this.SecureStorageReadCompleted?.Invoke(sender, args);
+                    this.stateManager.SecureStorageReadException += (sender, args) => this.SecureStorageReadException?.Invoke(sender, args);
+                    this.stateManager.SecureStorageWriteStarted += (sender, args) => this.SecureStorageWriteStarted?.Invoke(sender, args);
+                    this.stateManager.SecureStorageWriteCompleted += (sender, args) => this.SecureStorageWriteCompleted?.Invoke(sender, args);
+                    this.stateManager.SecureStorageWriteException += (sender, args) => this.SecureStorageWriteException?.Invoke(sender, args);
                 }
             }
+        }
+
+        /// <summary>
+        /// Gets or sets the IoC containter.
+        /// </summary>
+        public TinyIoCContainer IoCContainer { get; set; }
+
+        /// <summary>
+        /// Write the current state to secure storage.
+        /// </summary>
+        public async Task SaveStateAsync()
+        {
+            await this.StateManager.WriteToSecureStorageAsync();
+        }
+
+        /// <summary>
+        /// Write the current state to secure storage.
+        /// </summary>
+        /// <param name="oktaContext">OktaContext whose state is saved.  Default is OktaContext.Current.</param>
+        public static async Task SaveState(OktaContext oktaContext = null)
+        {
+            oktaContext = oktaContext ?? Current;
+            await oktaContext.SaveStateAsync();
+        }
+
+        /// <summary>
+        /// Load state from secure storage.
+        /// </summary>
+        /// <returns>A value indicating if state was loaded successfully.</returns>
+        public async Task<bool> LoadStateAsync()
+        {
+            OktaStateManager stateManager = await this.StateManager.ReadFromSecureStorageAsync();
+            if (stateManager != null)
+            {
+                this.StateManager = stateManager;
+            }
+
+            return stateManager != null;
+        }
+
+        /// <summary>
+        /// Get an instance of the specified generic type T from the underlying IoC container.
+        /// </summary>
+        /// <typeparam name="T">The type to return.</typeparam>
+        /// <returns>{T}.</returns>
+        public static T GetService<T>()
+            where T : class
+        {
+            return Current?.IoCContainer?.Resolve<T>();
+        }
+
+        /// <summary>
+        /// Register default implementations of Okta services into the specified container.
+        /// </summary>
+        /// <param name="container">The container.</param>
+        public static void RegisterOktaDefaults(TinyIoCContainer container)
+        {
+            // additional future service registrations go here
+            container.Register<SecureKeyValueStore, OktaSecureKeyValueStore>();
+            Current.IoCContainer = container;
+        }
+
+        /// <summary>
+        /// Creates or replaces a registration for the specified interface with the specified implementation.
+        /// </summary>
+        /// <typeparam name="TInterfaceType">Type to register</typeparam>
+        /// <typeparam name="TImplementationType">Type to instantiate that implements RegisterType</typeparam>
+        public static void RegisterServiceImplementation<TInterfaceType, TImplementationType>()
+            where TInterfaceType : class
+            where TImplementationType : class, TInterfaceType
+        {
+            Current?.IoCContainer?.Register<TInterfaceType, TImplementationType>();
+        }
+
+        /// <summary>
+        /// Creates or replaces a container class registration with a specific, strong referenced, instance.
+        /// </summary>
+        /// <typeparam name="TInterfaceType">The type to register.</typeparam>
+        /// <param name="instance">Instance of RegisterType to register.</param>
+        public static void RegisterServiceImplementation<TInterfaceType>(object instance)
+        {
+            Current?.IoCContainer?.Register(typeof(TInterfaceType), instance);
         }
 
         /// <summary>
@@ -292,7 +439,41 @@ namespace Okta.Xamarin
         }
 
         /// <summary>
-        /// Initialize OktaContext.Current with the specified default client.
+        /// Initialize OktaContext.Current services with the implementations in the specified inverson of control container.
+        /// </summary>
+        /// <param name="iocContainer">The inversion of control container.</param>
+        public static void ServiceInit(TinyIoCContainer iocContainer)
+        {
+            Current.InitServices(iocContainer);
+        }
+
+        /// <summary>
+        /// Initialize services using the specified container.
+        /// </summary>
+        /// <param name="iocContainer">The inversion of control container.</param>
+        public void InitServices(TinyIoCContainer iocContainer)
+        {
+            try
+            {
+                this.InitServicesStarted?.Invoke(this, new InitServicesEventArgs { TinyIoCContainer = iocContainer });
+                this.IoCContainer = iocContainer;
+
+                this.OidcClient = iocContainer.Resolve<IOidcClient>();
+                this.SecureKeyValueStore = iocContainer.Resolve<SecureKeyValueStore>();
+
+                // future services
+                // to be added here
+
+                this.InitServicesCompleted?.Invoke(this, new InitServicesEventArgs { TinyIoCContainer = iocContainer });
+            }
+            catch (Exception ex)
+            {
+                this.InitServicesException?.Invoke(this, new InitServicesEventArgs { Exception = ex });
+            }
+        }
+
+        /// <summary>
+        /// Initialize OktaContext.Current with the specified client.
         /// </summary>
         /// <param name="oidcClient">The client.</param>
         public static void Init(IOidcClient oidcClient)

--- a/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
@@ -250,7 +250,7 @@ namespace Okta.Xamarin
         /// </summary>
         public async Task SaveStateAsync()
         {
-            await this.StateManager.WriteToSecureStorageAsync();
+            await this.StateManager?.WriteToSecureStorageAsync();
         }
 
         /// <summary>

--- a/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
@@ -585,7 +585,7 @@ namespace Okta.Xamarin
         }
 
         /// <summary>
-        /// Initialize OktaContext.Current services with the implementations in the specified inverson of control container.
+        /// Initialize OktaContext.Current services with the implementations in the specified inversion of control container.
         /// </summary>
         /// <param name="iocContainer">The inversion of control container.</param>
         public static void ServiceInit(TinyIoCContainer iocContainer)

--- a/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
@@ -26,6 +26,7 @@ namespace Okta.Xamarin
         /// </summary>
         public OktaContext()
         {
+            this.stateManager = new OktaStateManager();
             this.IoCContainer = new TinyIoCContainer();
         }
 
@@ -268,6 +269,11 @@ namespace Okta.Xamarin
         /// <returns>A value indicating if state was loaded successfully.</returns>
         public async Task<bool> LoadStateAsync()
         {
+            if (this.StateManager == null)
+            {
+                this.StateManager = new OktaStateManager();
+            }
+
             OktaStateManager stateManager = await this.StateManager.ReadFromSecureStorageAsync();
             if (stateManager != null)
             {

--- a/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
@@ -256,7 +256,7 @@ namespace Okta.Xamarin
         /// Write the current state to secure storage.
         /// </summary>
         /// <param name="oktaContext">OktaContext whose state is saved.  Default is OktaContext.Current.</param>
-        public static async Task SaveState(OktaContext oktaContext = null)
+        public static async Task SaveStateAsync(OktaContext oktaContext = null)
         {
             oktaContext = oktaContext ?? Current;
             await oktaContext.SaveStateAsync();
@@ -275,6 +275,17 @@ namespace Okta.Xamarin
             }
 
             return stateManager != null;
+        }
+
+        /// <summary>
+        /// Load state from secure storage.
+        /// </summary>
+        /// <param name="oktaContext">The context to load state for.</param>
+        /// <returns>A value indicating if state was loaded successfully.</returns>
+        public static async Task<bool> LoadStateAsync(OktaContext oktaContext = null)
+        {
+            oktaContext = oktaContext ?? Current;
+            return await oktaContext.LoadStateAsync();
         }
 
         /// <summary>
@@ -319,6 +330,60 @@ namespace Okta.Xamarin
         public static void RegisterServiceImplementation<TInterfaceType>(object instance)
         {
             Current?.IoCContainer?.Register(typeof(TInterfaceType), instance);
+        }
+
+        /// <summary>
+        /// Convenience method to add a listener to the OktaContext.Current.SecureStorageReadStarted event.
+        /// </summary>
+        /// <param name="secureStorageReadEventHandler">The event handler.</param>
+        public static void AddSecureStorageReadStartedListener(EventHandler<SecureStorageEventArgs> secureStorageReadEventHandler)
+        {
+            Current.SecureStorageReadStarted += secureStorageReadEventHandler;
+        }
+
+        /// <summary>
+        /// Convenience method to add a listener to the OktaContext.Current.SecureStorageReadCompleted event.
+        /// </summary>
+        /// <param name="secureStorageReadEventHandler">The event handler.</param>
+        public static void AddSecureStorageReadCompletedListener(EventHandler<SecureStorageEventArgs> secureStorageReadEventHandler)
+        {
+            Current.SecureStorageReadCompleted += secureStorageReadEventHandler;
+        }
+
+        /// <summary>
+        /// Convenience method to add a listener to the OktaContext.Current.SecureStorageReadException event.
+        /// </summary>
+        /// <param name="secureStorageExceptionHandler">The event handler.</param>
+        public static void AddSecureStorageReadExceptionListener(EventHandler<SecureStorageExceptionEventArgs> secureStorageExceptionHandler)
+        {
+            Current.SecureStorageReadException += secureStorageExceptionHandler;
+        }
+
+        /// <summary>
+        /// Convenience method to add a listener to the OktaContext.Current.SecureStorageWriteStarted event.
+        /// </summary>
+        /// <param name="secureStorageWriteEventHandler">The event handler.</param>
+        public static void AddSecureStorageWriteStartedListener(EventHandler<SecureStorageEventArgs> secureStorageWriteEventHandler)
+        {
+            Current.SecureStorageWriteStarted += secureStorageWriteEventHandler;
+        }
+
+        /// <summary>
+        /// Convenience method to add a listener to the OktaContext.Current.SecureStorageWriteCompleted event.
+        /// </summary>
+        /// <param name="secureStorageWriteEventHandler">The event handler.</param>
+        public static void AddSecureStorageWriteCompletedListener(EventHandler<SecureStorageEventArgs> secureStorageWriteEventHandler)
+        {
+            Current.SecureStorageWriteCompleted += secureStorageWriteEventHandler;
+        }
+
+        /// <summary>
+        /// Convenience method to add a listener to the OktaContext.Current.SecureStorageWriteException event.
+        /// </summary>
+        /// <param name="secureStorageExceptionHandler">The event handler.</param>
+        public static void AddSecureStorageWriteExceptionListener(EventHandler<SecureStorageExceptionEventArgs> secureStorageExceptionHandler)
+        {
+            Current.SecureStorageWriteException += secureStorageExceptionHandler;
         }
 
         /// <summary>

--- a/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="OktaState.cs" company="Okta, Inc">
+﻿// <copyright file="OktaStateManager.cs" company="Okta, Inc">
 // Copyright (c) 2019-present Okta, Inc. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Okta.Xamarin.Services;
 
 namespace Okta.Xamarin
 {
@@ -16,6 +18,11 @@ namespace Okta.Xamarin
     /// </summary>
     public class OktaStateManager : IOktaStateManager
     {
+        /// <summary>
+        /// The key used to store and retrieve a representation of the state manager in secure storage. 
+        /// </summary>
+        public const string StoreKey = "OktaState";
+
         private IOidcClient client;
 
         /// <summary>
@@ -23,6 +30,18 @@ namespace Okta.Xamarin
         /// </summary>
         public OktaStateManager()
         {
+            try
+            {
+                OktaStateManager fromSecureStorage = this.ReadFromSecureStorageAsync().Result;
+                if (fromSecureStorage != null)
+                {
+                    this.Copy(fromSecureStorage);
+                }
+            }
+            catch
+            {
+                // swallow
+            }
         }
 
         /// <summary>
@@ -48,32 +67,53 @@ namespace Okta.Xamarin
         public event EventHandler<RequestExceptionEventArgs> RequestException;
 
         /// <inheritdoc/>
-        public string TokenType { get; private set; }
+        public event EventHandler<SecureStorageExceptionEventArgs> SecureStorageWriteException;
 
         /// <inheritdoc/>
-        public string AccessToken { get; private set; }
+        public event EventHandler<SecureStorageExceptionEventArgs> SecureStorageReadException;
 
         /// <inheritdoc/>
-        public string IdToken { get; private set; }
+        public event EventHandler<SecureStorageEventArgs> SecureStorageWriteStarted;
 
         /// <inheritdoc/>
-        public string RefreshToken { get; private set; }
+        public event EventHandler<SecureStorageEventArgs> SecureStorageWriteCompleted;
 
         /// <inheritdoc/>
-        public string Scope { get; private set; }
+        public event EventHandler<SecureStorageEventArgs> SecureStorageReadStarted;
 
         /// <inheritdoc/>
-        public DateTimeOffset? Expires { get; private set; }
+        public event EventHandler<SecureStorageEventArgs> SecureStorageReadCompleted;
+
+        /// <inheritdoc/>
+        public string TokenType { get; set; }
+
+        /// <inheritdoc/>
+        public string AccessToken { get; set; }
+
+        /// <inheritdoc/>
+        public string IdToken { get; set; }
+
+        /// <inheritdoc/>
+        public string RefreshToken { get; set; }
+
+        /// <inheritdoc/>
+        public string Scope { get; set; }
+
+        /// <inheritdoc/>
+        public DateTimeOffset? Expires { get; set; }
 
         /// <summary>
         /// Gets the most recent renew response or null.
         /// </summary>
+        [JsonIgnore]
         public RenewResponse RenewResponse { get; private set; }
 
         /// <inheritdoc/>
+        [JsonIgnore]
         public IOktaConfig Config { get; set; }
 
         /// <inheritdoc/>
+        [JsonIgnore]
         public IOidcClient Client
         {
             get => this.client;
@@ -85,6 +125,7 @@ namespace Okta.Xamarin
         }
 
         /// <inheritdoc/>
+        [JsonIgnore]
         public bool IsAuthenticated
         {
             get
@@ -113,16 +154,115 @@ namespace Okta.Xamarin
             }
         }
 
-        /// <inheritdoc/>
-        public async Task WriteToSecureStorageAsync() // to be implemented on OKTA-363613 v2.1
+        /// <summary>
+        /// Copies the state of the specified state manager to the current instance.
+        /// </summary>
+        /// <param name="oktaStateManager">The state manager to copy.</param>
+        protected void Copy(OktaStateManager oktaStateManager)
         {
-            throw new NotImplementedException();
+            if (oktaStateManager == null)
+            {
+                return;
+            }
+
+            this.Config = oktaStateManager.Config;
+            this.Client = oktaStateManager.Client;
+            this.TokenType = oktaStateManager.TokenType;
+            this.AccessToken = oktaStateManager.AccessToken;
+            this.IdToken = oktaStateManager.IdToken;
+            this.RefreshToken = oktaStateManager.RefreshToken;
+            this.Scope = oktaStateManager.Scope;
+            this.Expires = oktaStateManager.Expires;
         }
 
         /// <inheritdoc/>
-        public async Task<OktaStateManager> ReadFromSecureStorageAsync(IOktaConfig config) // to be implemented on OKTA-363613 v2.1
+        public async Task WriteToSecureStorageAsync()
         {
-            throw new NotImplementedException();
+            try
+            {
+                this.OnSecureStorageWriteStarted(new SecureStorageEventArgs { OktaStateManager = this });
+                SecureKeyValueStore secureKeyValueStore = OktaContext.GetService<SecureKeyValueStore>();
+                await secureKeyValueStore.SetAsync(StoreKey, this.ToJson());
+                this.OnSecureStorageWriteCompleted(new SecureStorageEventArgs { OktaStateManager = this });
+            }
+            catch (Exception ex)
+            {
+                this.OnSecureStorageWriteException(new SecureStorageExceptionEventArgs { Exception = ex });
+            }
+        }
+
+        protected void OnSecureStorageWriteStarted(SecureStorageEventArgs eventArgs)
+        {
+            this.SecureStorageWriteStarted?.Invoke(this, eventArgs);
+        }
+
+        protected void OnSecureStorageWriteCompleted(SecureStorageEventArgs eventArgs)
+        {
+            this.SecureStorageWriteCompleted?.Invoke(this, eventArgs);
+        }
+
+        /// <summary>
+        /// Raises the SecureStorageWriteException event.
+        /// </summary>
+        /// <param name="eventArgs">The event arguments.</param>
+        protected void OnSecureStorageWriteException(SecureStorageExceptionEventArgs eventArgs)
+        {
+            this.SecureStorageWriteException?.Invoke(this, eventArgs);
+        }
+
+        /// <inheritdoc/>
+        public async Task<OktaStateManager> ReadFromSecureStorageAsync()
+        {
+            return await this.ReadFromSecureStorageAsync(OktaContext.GetService<IOktaConfig>());
+        }
+
+        /// <inheritdoc/>
+        public async Task<OktaStateManager> ReadFromSecureStorageAsync(IOktaConfig config)
+        {
+            return await this.ReadFromSecureStorageAsync(config, OktaContext.GetService<IOidcClient>());
+        }
+
+        /// <inheritdoc/>
+        public async Task<OktaStateManager> ReadFromSecureStorageAsync(IOktaConfig config, IOidcClient client)
+        {
+            try
+            {
+                this.OnSecureStorageReadStarted(new SecureStorageEventArgs { OktaStateManager = this });
+                SecureKeyValueStore secureKeyValueStore = OktaContext.GetService<SecureKeyValueStore>();
+                OktaStateManager oktaStateManager = await secureKeyValueStore.GetAsync<OktaStateManager>(StoreKey);
+                if (oktaStateManager != null)
+                {
+                    oktaStateManager.Config = config;
+                    oktaStateManager.Client = client;
+                }
+
+                this.OnSecureStorageReadCompleted(new SecureStorageEventArgs { OktaStateManager = oktaStateManager });
+                return oktaStateManager;
+            }
+            catch (Exception ex)
+            {
+                this.OnSecureStorageReadException(new SecureStorageExceptionEventArgs { Exception = ex });
+                return null;
+            }
+        }
+
+        protected void OnSecureStorageReadStarted(SecureStorageEventArgs eventArgs)
+        {
+            this.SecureStorageReadStarted?.Invoke(this, eventArgs);
+        }
+
+        protected void OnSecureStorageReadCompleted(SecureStorageEventArgs eventArgs)
+        {
+            this.SecureStorageReadCompleted?.Invoke(this, eventArgs);
+        }
+
+        /// <summary>
+        /// Raises the SecureStorageReadException event.
+        /// </summary>
+        /// <param name="eventArgs">The event arguments.</param>
+        protected void OnSecureStorageReadException(SecureStorageExceptionEventArgs eventArgs)
+        {
+            this.SecureStorageReadException?.Invoke(this, eventArgs);
         }
 
         /// <inheritdoc/>
@@ -200,6 +340,11 @@ namespace Okta.Xamarin
             this.Scope = string.Empty;
             this.Expires = null;
             this.RefreshToken = string.Empty;
+        }
+
+        public string ToJson(Formatting formatting = Formatting.Indented)
+        {
+            return JsonConvert.SerializeObject(this, formatting);
         }
     }
 }

--- a/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
@@ -180,11 +180,19 @@ namespace Okta.Xamarin
             }
         }
 
+        /// <summary>
+        /// Raises the SecureStorageWriteStarted event.
+        /// </summary>
+        /// <param name="eventArgs">The event arguments.</param>
         protected void OnSecureStorageWriteStarted(SecureStorageEventArgs eventArgs)
         {
             this.SecureStorageWriteStarted?.Invoke(this, eventArgs);
         }
 
+        /// <summary>
+        /// Raises the SecureStorageWriteCompleted event.
+        /// </summary>
+        /// <param name="eventArgs">The event arguments.</param>
         protected void OnSecureStorageWriteCompleted(SecureStorageEventArgs eventArgs)
         {
             this.SecureStorageWriteCompleted?.Invoke(this, eventArgs);

--- a/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
@@ -251,11 +251,19 @@ namespace Okta.Xamarin
             return this;
         }
 
+        /// <summary>
+        /// Raises the SecureStorageReadStarted event.
+        /// </summary>
+        /// <param name="eventArgs"></param>
         protected void OnSecureStorageReadStarted(SecureStorageEventArgs eventArgs)
         {
             this.SecureStorageReadStarted?.Invoke(this, eventArgs);
         }
 
+        /// <summary>
+        /// Raises the SecureStorageReadCompleted event.
+        /// </summary>
+        /// <param name="eventArgs"></param>
         protected void OnSecureStorageReadCompleted(SecureStorageEventArgs eventArgs)
         {
             this.SecureStorageReadCompleted?.Invoke(this, eventArgs);

--- a/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
@@ -246,6 +246,14 @@ namespace Okta.Xamarin
             }
         }
 
+        /// <inheritdoc/>
+        public async Task<OktaStateManager> ClearSecureStorageStateAsync()
+        {
+            this.Clear();
+            await this.WriteToSecureStorageAsync();
+            return this;
+        }
+
         protected void OnSecureStorageReadStarted(SecureStorageEventArgs eventArgs)
         {
             this.SecureStorageReadStarted?.Invoke(this, eventArgs);

--- a/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
@@ -254,17 +254,17 @@ namespace Okta.Xamarin
         /// <summary>
         /// Raises the SecureStorageReadStarted event.
         /// </summary>
-        /// <param name="eventArgs"></param>
+        /// <param name="eventArgs">The event arguments.</param>
         protected void OnSecureStorageReadStarted(SecureStorageEventArgs eventArgs)
         {
             this.SecureStorageReadStarted?.Invoke(this, eventArgs);
         }
 
-        /// <summary>
-        /// Raises the SecureStorageReadCompleted event.
-        /// </summary>
-        /// <param name="eventArgs"></param>
-        protected void OnSecureStorageReadCompleted(SecureStorageEventArgs eventArgs)
+		/// <summary>
+		/// Raises the SecureStorageReadCompleted event.
+		/// </summary>
+		/// <param name="eventArgs">The event arguments.</param>
+		protected void OnSecureStorageReadCompleted(SecureStorageEventArgs eventArgs)
         {
             this.SecureStorageReadCompleted?.Invoke(this, eventArgs);
         }

--- a/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
@@ -260,11 +260,11 @@ namespace Okta.Xamarin
             this.SecureStorageReadStarted?.Invoke(this, eventArgs);
         }
 
-		/// <summary>
-		/// Raises the SecureStorageReadCompleted event.
-		/// </summary>
-		/// <param name="eventArgs">The event arguments.</param>
-		protected void OnSecureStorageReadCompleted(SecureStorageEventArgs eventArgs)
+        /// <summary>
+        /// Raises the SecureStorageReadCompleted event.
+        /// </summary>
+        /// <param name="eventArgs">The event arguments.</param>
+        protected void OnSecureStorageReadCompleted(SecureStorageEventArgs eventArgs)
         {
             this.SecureStorageReadCompleted?.Invoke(this, eventArgs);
         }

--- a/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
@@ -30,18 +30,6 @@ namespace Okta.Xamarin
         /// </summary>
         public OktaStateManager()
         {
-            try
-            {
-                OktaStateManager fromSecureStorage = this.ReadFromSecureStorageAsync().Result;
-                if (fromSecureStorage != null)
-                {
-                    this.Copy(fromSecureStorage);
-                }
-            }
-            catch
-            {
-                // swallow
-            }
         }
 
         /// <summary>
@@ -136,6 +124,7 @@ namespace Okta.Xamarin
         }
 
         /// <inheritdoc/>
+        [JsonIgnore]
         public HttpResponseMessage LastApiResponse { get => this.Client?.LastApiResponse; }
 
         /// <inheritdoc/>
@@ -350,6 +339,7 @@ namespace Okta.Xamarin
             this.RefreshToken = string.Empty;
         }
 
+        /// <inheritdoc/>
         public string ToJson(Formatting formatting = Formatting.Indented)
         {
             return JsonConvert.SerializeObject(this, formatting);

--- a/Okta.Xamarin/Okta.Xamarin/SecureStorageEventArgs.cs
+++ b/Okta.Xamarin/Okta.Xamarin/SecureStorageEventArgs.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Okta.Xamarin
+{
+	public class SecureStorageEventArgs : EventArgs
+	{
+		public IOktaStateManager OktaStateManager { get; set; }
+	}
+}

--- a/Okta.Xamarin/Okta.Xamarin/SecureStorageEventArgs.cs
+++ b/Okta.Xamarin/Okta.Xamarin/SecureStorageEventArgs.cs
@@ -1,11 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// <copyright file="SecureStorageEventArgs.cs" company="Okta, Inc">
+// Copyright (c) 2020 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
 
 namespace Okta.Xamarin
 {
-	public class SecureStorageEventArgs : EventArgs
-	{
-		public IOktaStateManager OktaStateManager { get; set; }
-	}
+    /// <summary>
+    /// Arguments relevant to secure storage events.
+    /// </summary>
+    public class SecureStorageEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets or sets the Okta state manager.
+        /// </summary>
+        public IOktaStateManager OktaStateManager { get; set; }
+    }
 }

--- a/Okta.Xamarin/Okta.Xamarin/SecureStorageExceptionEventArgs.cs
+++ b/Okta.Xamarin/Okta.Xamarin/SecureStorageExceptionEventArgs.cs
@@ -1,11 +1,32 @@
-﻿using System;
+﻿// <copyright file="SecureStorageExceptionEventArgs.cs" company="Okta, Inc">
+// Copyright (c) 2020 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace Okta.Xamarin
 {
-	public class SecureStorageExceptionEventArgs: EventArgs
-	{
-		public Exception Exception { get; set; }
-	}
+    /// <summary>
+    /// Arguments relevant to to secure storage exceptions.
+    /// </summary>
+    public class SecureStorageExceptionEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets or sets the Okta config.
+        /// </summary>
+        public IOktaConfig OktaConfig { get; set; }
+
+        /// <summary>
+        /// Gets or sets the OIDC client.
+        /// </summary>
+        public IOidcClient OidcClient{ get; set; }
+
+        /// <summary>
+        /// Gets or sets the exception.
+        /// </summary>
+        public Exception Exception { get; set; }
+    }
 }

--- a/Okta.Xamarin/Okta.Xamarin/SecureStorageExceptionEventArgs.cs
+++ b/Okta.Xamarin/Okta.Xamarin/SecureStorageExceptionEventArgs.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Okta.Xamarin
+{
+	public class SecureStorageExceptionEventArgs: EventArgs
+	{
+		public Exception Exception { get; set; }
+	}
+}

--- a/Okta.Xamarin/Okta.Xamarin/SecureStorageExceptionEventArgs.cs
+++ b/Okta.Xamarin/Okta.Xamarin/SecureStorageExceptionEventArgs.cs
@@ -10,7 +10,7 @@ using System.Text;
 namespace Okta.Xamarin
 {
     /// <summary>
-    /// Arguments relevant to to secure storage exceptions.
+    /// Arguments relevant to secure storage exceptions.
     /// </summary>
     public class SecureStorageExceptionEventArgs : EventArgs
     {

--- a/Okta.Xamarin/Okta.Xamarin/Services/IKeyValueStore.cs
+++ b/Okta.Xamarin/Okta.Xamarin/Services/IKeyValueStore.cs
@@ -1,0 +1,50 @@
+﻿// <copyright file="IKeyValueStore.cs" company="Okta, Inc">
+// Copyright (c) 2020 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System.Threading.Tasks;
+
+namespace Okta.Xamarin.Services
+{
+    /// <summary>
+    /// An interface defining a basic key-value store.
+    /// </summary>
+    public interface IKeyValueStore
+    {
+        /// <summary>
+        /// Get the value associated with the specified key as the specified generic type.
+        /// </summary>
+        /// <typeparam name="T">The type to deserialize the object as.</typeparam>
+        /// <param name="key">The key.</param>
+        /// <returns>{T}.</returns>
+        Task<T> GetAsync<T>(string key);
+
+        /// <summary>
+        /// Get the string value associated with the specified key.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <returns>string.</returns>
+        Task<string> GetAsync(string key);
+
+        /// <summary>
+        /// Sets the value for the specified key.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        /// <returns>Task.</returns>
+        Task SetAsync(string key, string value);
+
+        /// <summary>
+        /// Removes the value for the specified key.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <returns>a boolean value indicating success or failure.</returns>
+        bool Remove(string key);
+
+        /// <summary>
+        /// Removes all values.
+        /// </summary>
+        void RemoveAll();
+    }
+}

--- a/Okta.Xamarin/Okta.Xamarin/Services/OktaSecureKeyValueStore.cs
+++ b/Okta.Xamarin/Okta.Xamarin/Services/OktaSecureKeyValueStore.cs
@@ -1,0 +1,53 @@
+﻿// <copyright file="SecureKeyValueStore.cs" company="Okta, Inc">
+// Copyright (c) 2020 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Xamarin.Essentials;
+
+namespace Okta.Xamarin.Services
+{
+    /// <summary>
+    /// A key value store that uses Xamarin.Essentials.SecureStorage as the backing store.
+    /// </summary>
+    public class OktaSecureKeyValueStore : SecureKeyValueStore
+    {
+        /// <inheritdoc/>
+        public override async Task<T> GetAsync<T>(string key)
+        {
+            string json = await this.GetAsync(key);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return default;
+            }
+
+            return JsonConvert.DeserializeObject<T>(json);
+        }
+
+        /// <inheritdoc/>
+        public override Task<string> GetAsync(string key)
+        {
+            return SecureStorage.GetAsync(key);
+        }
+
+        /// <inheritdoc/>
+        public override bool Remove(string key)
+        {
+            return SecureStorage.Remove(key);
+        }
+
+        /// <inheritdoc/>
+        public override void RemoveAll()
+        {
+            SecureStorage.RemoveAll();
+        }
+
+        /// <inheritdoc/>
+        public override Task SetAsync(string key, string value)
+        {
+            return SecureStorage.SetAsync(key, value);
+        }
+    }
+}

--- a/Okta.Xamarin/Okta.Xamarin/Services/SecureKeyValueStore.cs
+++ b/Okta.Xamarin/Okta.Xamarin/Services/SecureKeyValueStore.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Okta.Xamarin.Services
+{
+    /// <summary>
+    /// An abstract base class denoting intent that implementations should be secure.
+    /// </summary>
+    public abstract class SecureKeyValueStore : IKeyValueStore
+    {
+        /// <summary>
+        /// Get the value associated with the specified key and deserialize it as the specified generic type.
+        /// The value is assumed to be a json string.
+        /// </summary>
+        /// <typeparam name="T">The type of the value.</typeparam>
+        /// <param name="key">The key.</param>
+        /// <returns>Task{T}.</returns>
+        public abstract Task<T> GetAsync<T>(string key);
+
+        /// <inheritdoc/>
+        public abstract Task<string> GetAsync(string key);
+
+        /// <inheritdoc/>
+        public abstract bool Remove(string key);
+
+        /// <inheritdoc/>
+        public abstract void RemoveAll();
+
+        /// <inheritdoc/>
+        public abstract Task SetAsync(string key, string value);
+    }
+}

--- a/Okta.Xamarin/Okta.Xamarin/TinyIoC/TinyIoCContainer.cs
+++ b/Okta.Xamarin/Okta.Xamarin/TinyIoC/TinyIoCContainer.cs
@@ -94,7 +94,7 @@
 using System.Runtime.Serialization;
 #endif
 
-namespace TinyIoC
+namespace Okta.Xamarin.TinyIoC
 {
     using System;
     using System.Collections.Generic;

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClient.Test.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClient.Test.cs
@@ -103,9 +103,9 @@ namespace Okta.Xamarin
             return GenerateAuthorizeUrl();
         }
 
-		public void RaiseRequestExceptionEvent(RequestExceptionEventArgs requestExceptionEventArgs)
-		{
-			this.OnRequestException(requestExceptionEventArgs);
-		}
-	}
+        public void RaiseRequestExceptionEvent(RequestExceptionEventArgs requestExceptionEventArgs)
+        {
+            this.OnRequestException(requestExceptionEventArgs);
+        }
+    }
 }

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaContextShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaContextShould.cs
@@ -168,7 +168,7 @@ namespace Okta.Xamarin.Test
         }
 
         [Fact]
-        public void RaiseEventOnSecureStorageReadException()
+        public void RaiseEventOnStateManagerSecureStorageReadException()
         {
             TestOktaStateManager testStateManager = new TestOktaStateManager();
             OktaContext oktaContext = new OktaContext() { StateManager = testStateManager };
@@ -186,7 +186,7 @@ namespace Okta.Xamarin.Test
         }
 
         [Fact]
-        public void RaiseEventOnSecureStorageWriteException()
+        public void RaiseEventOnStateManagerSecureStorageWriteException()
         {
             TestOktaStateManager testStateManger = new TestOktaStateManager();
             OktaContext oktaContext = new OktaContext() { StateManager = testStateManger };

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaContextShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaContextShould.cs
@@ -22,6 +22,9 @@ namespace Okta.Xamarin.Test
         public void RaiseSecureStorageWriteEventsOnSaveStateAsync()
         {
             TestOktaStateManager testOktaStateManager = new TestOktaStateManager();
+            OktaContext oktaContext = new OktaContext() { StateManager = testOktaStateManager };
+            OktaContext.Current = oktaContext;
+
             IOktaConfig testConfig = Substitute.For<IOktaConfig>();
             IOidcClient testClient = Substitute.For<IOidcClient>();
             SecureKeyValueStore testSecureKeyValueStore = Substitute.For<SecureKeyValueStore>();
@@ -29,13 +32,13 @@ namespace Okta.Xamarin.Test
             OktaContext.RegisterServiceImplementation<SecureKeyValueStore>(testSecureKeyValueStore);
             OktaContext.RegisterServiceImplementation<IOktaConfig>(testConfig);
             OktaContext.RegisterServiceImplementation<IOidcClient>(testClient);
-            OktaContext oktaContext = new OktaContext() { StateManager = testOktaStateManager };
+
             bool? startedEventWasRaised = false;
             bool? completedEventWasRaised = false;
-            oktaContext.SecureStorageWriteStarted += (sender, args) => startedEventWasRaised = true;
-            oktaContext.SecureStorageWriteCompleted += (sender, args) => completedEventWasRaised = true;
+            OktaContext.AddSecureStorageWriteStartedListener((sender, args) => startedEventWasRaised = true);
+            OktaContext.AddSecureStorageWriteCompletedListener((sender, args) => completedEventWasRaised = true);
 
-            oktaContext.SaveStateAsync().Wait();
+            OktaContext.SaveStateAsync().Wait();
 
             startedEventWasRaised.Should().BeTrue();
             completedEventWasRaised.Should().BeTrue();
@@ -45,6 +48,9 @@ namespace Okta.Xamarin.Test
         public void RaiseSecureStorageReadEventsOnLoadStateAsync()
         {
             TestOktaStateManager testOktaStateManager = new TestOktaStateManager();
+            OktaContext oktaContext = new OktaContext() { StateManager = testOktaStateManager };
+            OktaContext.Current = oktaContext;
+
             IOktaConfig testConfig = Substitute.For<IOktaConfig>();
             IOidcClient testClient = Substitute.For<IOidcClient>();
             SecureKeyValueStore testSecureKeyValueStore = Substitute.For<SecureKeyValueStore>();
@@ -52,13 +58,13 @@ namespace Okta.Xamarin.Test
             OktaContext.RegisterServiceImplementation<SecureKeyValueStore>(testSecureKeyValueStore);
             OktaContext.RegisterServiceImplementation<IOktaConfig>(testConfig);
             OktaContext.RegisterServiceImplementation<IOidcClient>(testClient);
-            OktaContext oktaContext = new OktaContext() { StateManager = testOktaStateManager };
+
             bool? startedEventWasRaised = false;
             bool? completedEventWasRaised = false;
-            oktaContext.SecureStorageReadStarted += (sender, args) => startedEventWasRaised = true;
-            oktaContext.SecureStorageReadCompleted += (sender, args) => completedEventWasRaised = true;
+            OktaContext.AddSecureStorageReadStartedListener((sender, args) => startedEventWasRaised = true);
+            OktaContext.AddSecureStorageReadCompletedListener((sender, args) => completedEventWasRaised = true);
 
-            bool loaded = oktaContext.LoadStateAsync().Result;
+            bool loaded = OktaContext.LoadStateAsync().Result;
 
             loaded.Should().BeTrue();
             startedEventWasRaised.Should().BeTrue();

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaContextShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaContextShould.cs
@@ -11,12 +11,96 @@ using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
+using Okta.Xamarin.Services;
 using Xunit;
 
 namespace Okta.Xamarin.Test
 {
     public class OktaContextShould
     {
+        [Fact]
+        public void RaiseSecureStorageWriteEventsOnSaveStateAsync()
+        {
+            TestOktaStateManager testOktaStateManager = new TestOktaStateManager();
+            IOktaConfig testConfig = Substitute.For<IOktaConfig>();
+            IOidcClient testClient = Substitute.For<IOidcClient>();
+            SecureKeyValueStore testSecureKeyValueStore = Substitute.For<SecureKeyValueStore>();
+            testSecureKeyValueStore.GetAsync<OktaStateManager>(OktaStateManager.StoreKey).Returns(testOktaStateManager);
+            OktaContext.RegisterServiceImplementation<SecureKeyValueStore>(testSecureKeyValueStore);
+            OktaContext.RegisterServiceImplementation<IOktaConfig>(testConfig);
+            OktaContext.RegisterServiceImplementation<IOidcClient>(testClient);
+            OktaContext oktaContext = new OktaContext() { StateManager = testOktaStateManager };
+            bool? startedEventWasRaised = false;
+            bool? completedEventWasRaised = false;
+            oktaContext.SecureStorageWriteStarted += (sender, args) => startedEventWasRaised = true;
+            oktaContext.SecureStorageWriteCompleted += (sender, args) => completedEventWasRaised = true;
+
+            oktaContext.SaveStateAsync().Wait();
+
+            startedEventWasRaised.Should().BeTrue();
+            completedEventWasRaised.Should().BeTrue();
+        }
+
+        [Fact]
+        public void RaiseSecureStorageReadEventsOnLoadStateAsync()
+        {
+            TestOktaStateManager testOktaStateManager = new TestOktaStateManager();
+            IOktaConfig testConfig = Substitute.For<IOktaConfig>();
+            IOidcClient testClient = Substitute.For<IOidcClient>();
+            SecureKeyValueStore testSecureKeyValueStore = Substitute.For<SecureKeyValueStore>();
+            testSecureKeyValueStore.GetAsync<OktaStateManager>(OktaStateManager.StoreKey).Returns(testOktaStateManager);
+            OktaContext.RegisterServiceImplementation<SecureKeyValueStore>(testSecureKeyValueStore);
+            OktaContext.RegisterServiceImplementation<IOktaConfig>(testConfig);
+            OktaContext.RegisterServiceImplementation<IOidcClient>(testClient);
+            OktaContext oktaContext = new OktaContext() { StateManager = testOktaStateManager };
+            bool? startedEventWasRaised = false;
+            bool? completedEventWasRaised = false;
+            oktaContext.SecureStorageReadStarted += (sender, args) => startedEventWasRaised = true;
+            oktaContext.SecureStorageReadCompleted += (sender, args) => completedEventWasRaised = true;
+
+            bool loaded = oktaContext.LoadStateAsync().Result;
+
+            loaded.Should().BeTrue();
+            startedEventWasRaised.Should().BeTrue();
+            completedEventWasRaised.Should().BeTrue();
+        }
+
+        [Fact]
+        public void RaiseEventOnSecureStorageReadException()
+        {
+            TestOktaStateManager testStateManager = new TestOktaStateManager();
+            OktaContext oktaContext = new OktaContext() { StateManager = testStateManager };
+
+            bool? eventWasRaised = false;
+            Exception testException = new Exception("This is a test exception");
+            oktaContext.SecureStorageReadException += (sender, args) =>
+            {
+                args.Exception.Should().Be(testException);
+                eventWasRaised = true;
+            };
+
+            testStateManager.RaiseSecureStorageReadException(new SecureStorageExceptionEventArgs { Exception = testException });
+            eventWasRaised.Should().BeTrue();
+        }
+
+        [Fact]
+        public void RaiseEventOnSecureStorageWriteException()
+        {
+            TestOktaStateManager testStateManger = new TestOktaStateManager();
+            OktaContext oktaContext = new OktaContext() { StateManager = testStateManger };
+
+            bool? eventWasRaised = false;
+            Exception testException = new Exception("This is a test exception");
+            oktaContext.SecureStorageWriteException += (sender, args) =>
+            {
+                args.Exception.Should().Be(testException);
+                eventWasRaised = true;
+            };
+
+            testStateManger.RaiseSecureStorageWriteException(new SecureStorageExceptionEventArgs { Exception = testException });
+            eventWasRaised.Should().BeTrue();
+        }
+
         [Fact]
         public void NotRaiseSignInCompleteOnOAuthException()
         {
@@ -172,6 +256,56 @@ namespace Okta.Xamarin.Test
 
             renewStartedRaised.Should().BeTrue();
             renewCompletedRaised.Should().BeTrue();
+        }
+
+        [Fact]
+        public void RaiseInitServicesEvents()
+        {
+            bool? initServicesStartedRaised = false;
+            bool? initServicesCompletedRaised = false;
+            bool? initServicesExceptionRaised = false;
+            OktaContext.Current.InitServicesStarted += (sender, args) => initServicesStartedRaised = true;
+            OktaContext.Current.InitServicesCompleted += (sender, args) => initServicesCompletedRaised = true;
+
+            TinyIoC.TinyIoCContainer container = new TinyIoC.TinyIoCContainer();
+            container.Register(Substitute.For<IOidcClient>());
+            container.Register(Substitute.For<SecureKeyValueStore>());
+            OktaContext.Current.InitServices(container);
+
+            initServicesStartedRaised.Should().BeTrue();
+            initServicesCompletedRaised.Should().BeTrue();
+            initServicesExceptionRaised.Should().BeFalse();
+        }
+
+        [Fact]
+        public void RaiseInitServicesExceptionEvent()
+        {
+            bool? initServicesStartedRaised = false;
+            bool? initServicesCompletedRaised = false;
+            bool? initServicesExceptionRaised = false;
+            OktaContext.Current.InitServicesStarted += (sender, args) => initServicesStartedRaised = true;
+            OktaContext.Current.InitServicesCompleted += (sender, args) =>
+            {
+                initServicesCompletedRaised = true;
+                throw new Exception("throwing exception to test that the related exception event is raised");
+            };
+            OktaContext.Current.InitServicesException += (sender, args) => initServicesExceptionRaised = true;
+
+            TinyIoC.TinyIoCContainer container = new TinyIoC.TinyIoCContainer();
+            container.Register(Substitute.For<IOidcClient>());
+            container.Register(Substitute.For<SecureKeyValueStore>());
+            OktaContext.Current.InitServices(container);
+
+            initServicesStartedRaised.Should().BeTrue();
+            initServicesCompletedRaised.Should().BeTrue();
+            initServicesExceptionRaised.Should().BeTrue();
+        }
+
+        [Fact]
+        public void HaveIoCContainer()
+        {
+            OktaContext context = new OktaContext();
+            context.IoCContainer.Should().NotBeNull();
         }
     }
 }

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaContextShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaContextShould.cs
@@ -19,6 +19,102 @@ namespace Okta.Xamarin.Test
     public class OktaContextShould
     {
         [Fact]
+        public void LoadState()
+        {
+            string testAccessToken = "load state test:  access token";
+            OktaContext oktaContext = new OktaContext() { StateManager = new OktaStateManager { AccessToken = null } };
+            OktaContext.Current = oktaContext;
+
+            IOktaConfig testConfig = Substitute.For<IOktaConfig>();
+            IOidcClient testClient = Substitute.For<IOidcClient>();
+            SecureKeyValueStore testSecureKeyValueStore = Substitute.For<SecureKeyValueStore>();
+            testSecureKeyValueStore.GetAsync<OktaStateManager>(OktaStateManager.StoreKey).Returns(new OktaStateManager { AccessToken = testAccessToken }); // represents what is in secure storage
+            OktaContext.RegisterServiceImplementation<SecureKeyValueStore>(testSecureKeyValueStore);
+            OktaContext.RegisterServiceImplementation<IOktaConfig>(testConfig);
+            OktaContext.RegisterServiceImplementation<IOidcClient>(testClient);
+
+            bool? completedEventWasRaised = false;
+            OktaContext.AddLoadStateCompletedListener((sender, args) =>
+            {
+                args.OktaStateManager.AccessToken.Should().Be(testAccessToken);
+                completedEventWasRaised = true;
+            });
+
+            OktaContext.AccessToken.Should().BeNull();
+
+            OktaContext.LoadStateAsync().Wait();
+
+            completedEventWasRaised.Should().BeTrue();
+            OktaContext.AccessToken.Should().BeEquivalentTo(testAccessToken);
+        }
+
+        [Fact]
+        public void NotLoadEmptyStateOverAuthenticatedState()
+        {
+            string testAccessToken = "test access token";
+            OktaContext oktaContext = new OktaContext() { StateManager = new OktaStateManager { AccessToken = testAccessToken } };
+            OktaContext.Current = oktaContext;
+
+            IOktaConfig testConfig = Substitute.For<IOktaConfig>();
+            IOidcClient testClient = Substitute.For<IOidcClient>();
+            SecureKeyValueStore testSecureKeyValueStore = Substitute.For<SecureKeyValueStore>();
+            testSecureKeyValueStore.GetAsync<OktaStateManager>(OktaStateManager.StoreKey).Returns(new OktaStateManager { AccessToken = null }); // represents what is in secure storage
+            OktaContext.RegisterServiceImplementation<SecureKeyValueStore>(testSecureKeyValueStore);
+            OktaContext.RegisterServiceImplementation<IOktaConfig>(testConfig);
+            OktaContext.RegisterServiceImplementation<IOidcClient>(testClient);
+
+            bool? completedEventWasRaised = false;
+            OktaContext.AddLoadStateCompletedListener((sender, args) =>
+            {
+                args.OktaStateManager.AccessToken.Should().Be(testAccessToken);
+                completedEventWasRaised = true;
+            });
+
+            OktaContext.AccessToken.Should().BeEquivalentTo(testAccessToken);
+
+            OktaContext.LoadStateAsync().Wait();
+
+            completedEventWasRaised.Should().BeTrue();
+            OktaContext.AccessToken.Should().BeEquivalentTo(testAccessToken); // Loading state should not overwrite existing access token with empty string
+        }
+
+        [Fact]
+        public void RaiseLoadStateExceptionEvent()
+        {
+            IOktaStateManager stateManager = Substitute.For<IOktaStateManager>();
+            stateManager.ReadFromSecureStorageAsync().Returns(new OktaStateManager());
+            OktaContext oktaContext = new OktaContext() { StateManager = stateManager };
+            OktaContext.Current = oktaContext;
+
+            bool? exceptionEventWasRaised = false;
+            OktaContext.AddLoadStateStartedListener((sender, args) => throw new Exception("This is a test exception to test that the exception event is raised"));
+            OktaContext.AddLoadStateExceptionListener((sender, args) => exceptionEventWasRaised = true);
+
+            OktaContext.LoadStateAsync().Wait();
+
+            exceptionEventWasRaised.Should().BeTrue();
+        }
+
+        [Fact]
+        public void RaiseLoadStateEvents()
+        {
+            IOktaStateManager stateManager = Substitute.For<IOktaStateManager>();
+            stateManager.ReadFromSecureStorageAsync().Returns(new OktaStateManager());
+            OktaContext oktaContext = new OktaContext() { StateManager = stateManager };
+            OktaContext.Current = oktaContext;
+
+            bool? startedEventWasRaised = false;
+            bool? completedEventWasRaised = false;
+            OktaContext.AddLoadStateStartedListener((sender, args) => startedEventWasRaised = true);
+            OktaContext.AddLoadStateCompletedListener((sender, args) => completedEventWasRaised = true);
+
+            OktaContext.LoadStateAsync().Wait();
+
+            startedEventWasRaised.Should().BeTrue();
+            completedEventWasRaised.Should().BeTrue();
+        }
+
+        [Fact]
         public void RaiseSecureStorageWriteEventsOnSaveStateAsync()
         {
             TestOktaStateManager testOktaStateManager = new TestOktaStateManager();

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/TestOktaStateManager.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/TestOktaStateManager.cs
@@ -3,6 +3,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
 using System.Threading.Tasks;
 
 namespace Okta.Xamarin.Test
@@ -10,6 +11,7 @@ namespace Okta.Xamarin.Test
     public class TestOktaStateManager: OktaStateManager
     {
         public TestOktaStateManager() : base() { }
+
         public TestOktaStateManager(string accessToken, string idToken = null, string refreshToken = null, int? expiresIn = null, string scope = null)
         : base(accessToken, null, idToken, refreshToken, expiresIn, scope) 
         {
@@ -22,6 +24,16 @@ namespace Okta.Xamarin.Test
         public override Task RevokeAsync(TokenKind tokenType)
         {
             return Task.Run(() => ++RevokeAsyncCallCount);
+        }
+
+        public void RaiseSecureStorageReadException(SecureStorageExceptionEventArgs eventArgs)
+        {
+            this.OnSecureStorageReadException(eventArgs);
+        }
+
+        public void RaiseSecureStorageWriteException(SecureStorageExceptionEventArgs eventArgs)
+        {
+            this.OnSecureStorageWriteException(eventArgs);
         }
     }
 }

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/TinyIoCContainerShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/TinyIoCContainerShould.cs
@@ -5,7 +5,7 @@
 
 using System.Threading.Tasks;
 using FluentAssertions;
-using TinyIoC;
+using Okta.Xamarin.TinyIoC;
 using Xunit;
 
 namespace Okta.Xamarin.Test


### PR DESCRIPTION
- Implemented `OktaStateManager.WriteToSecureStorageAsync` which uses `Xamarin.Essentials.SecureStorage` to write a json representation of `OktaStateManger` to secure storage.
- Refactored `OktaMainActivity` and `OktaAppDelegate` to change initialization process.
- Added convenience methods  to `OktaContext` to manage loading and saving state.
- Added initialization related events to `OktaContext`
- Added secure storage related events to `OktaContext`
- Added unit tests

**Note - Tokens are not automatically stored and retrieved in secure storage; this implementation allows one to subscribe to the appropriate events and make the appropriate method calls to store tokens in secure storage if one chose to do so.**


https://user-images.githubusercontent.com/63638027/128194370-5a6e7550-7a8a-4be9-98b1-35d555f576f7.mp4

