### PR TITLE
OKTA-415847: ensure Revoke calls use authorization server id from config

### DIFF
--- a/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
@@ -667,7 +667,7 @@ namespace Okta.Xamarin
         /// <returns>Task representing the operation.</returns>
         public async Task RevokeAccessTokenAsync(string accessToken)
         {
-            _ = await this.PerformAuthorizationServerRequestAsync(HttpMethod.Post, "/revoke", new Dictionary<string, string>(), new Dictionary<string, string> { { "token", accessToken }, { "token_type_hint", "access_token" }, { "client_id", this.Config.ClientId } });
+            _ = await this.PerformAuthorizationServerRequestAsync(HttpMethod.Post, "/revoke", new Dictionary<string, string>(), new Dictionary<string, string> { { "token", accessToken }, { "token_type_hint", "access_token" }, { "client_id", this.Config.ClientId } }, this.Config.AuthorizationServerId ?? "default");
         }
 
         /// <summary>
@@ -677,7 +677,7 @@ namespace Okta.Xamarin
         /// <returns>Task representing the operation.</returns>
         public async Task RevokeRefreshTokenAsync(string refreshToken)
         {
-            _ = await this.PerformAuthorizationServerRequestAsync(HttpMethod.Post, "/revoke", new Dictionary<string, string>(), new Dictionary<string, string> { { "token", refreshToken }, { "token_type_hint", "refresh_token" }, { "client_id", this.Config.ClientId } });
+            _ = await this.PerformAuthorizationServerRequestAsync(HttpMethod.Post, "/revoke", new Dictionary<string, string>(), new Dictionary<string, string> { { "token", refreshToken }, { "token_type_hint", "refresh_token" }, { "client_id", this.Config.ClientId } }, this.Config.AuthorizationServerId ?? "default");
         }
     }
 }

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClient.Test.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClient.Test.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -103,9 +104,33 @@ namespace Okta.Xamarin
             return GenerateAuthorizeUrl();
         }
 
-		public void RaiseRequestExceptionEvent(RequestExceptionEventArgs requestExceptionEventArgs)
-		{
-			this.OnRequestException(requestExceptionEventArgs);
-		}
-	}
+        public void RaiseRequestExceptionEvent(RequestExceptionEventArgs requestExceptionEventArgs)
+        {
+            this.OnRequestException(requestExceptionEventArgs);
+        }
+
+        /// <summary>
+        /// Gets or sets the number of time the PerformAuthorizationServerRequestAsync method was called.
+        /// </summary>
+        public int PerformAuthorizationServerRequestCallCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets a dynamic object representing the arguments passed to the PerformAuthorizationServerRequestAsync method.
+        /// </summary>
+        public dynamic PerformAuthorizationServerRequestArgumentsReceived { get; set; }
+
+        protected override async Task<string> PerformAuthorizationServerRequestAsync(HttpMethod httpMethod, string path, Dictionary<string, string> headers, string authorizationServerId = "default", params KeyValuePair<string, string>[] formUrlEncodedContent)
+        {
+            ++this.PerformAuthorizationServerRequestCallCount;
+            this.PerformAuthorizationServerRequestArgumentsReceived = new
+            {
+                HttpMethod = httpMethod,
+                Path = path,
+                Headers = headers,
+                AuthorizationServerId = authorizationServerId,
+                FormUrlEncodedContent = formUrlEncodedContent,
+            };
+            return "test response";
+        }
+    }
 }

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClientShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClientShould.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Okta.Xamarin.Test
 {
-	public class OidcClientShould
+    public class OidcClientShould
     {
         [Fact]
         public void FailWithInvalidConfig()
@@ -21,7 +21,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public void GetCorrectAuthUrl()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect+&TEST!@url%20Encode#*^(0)", "com.test:/logout") { Scope = "test hello test_scope" });
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect+&TEST!@url%20Encode#*^(0)", "com.test:/logout") { Scope = "test hello test_scope" });
 
             string url = client.GenerateAuthorizeUrlTest();
             Assert.StartsWith("https://dev-00000.oktapreview.com/oauth2/default/v1/authorize?", url);
@@ -33,7 +33,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public async void LaunchBrowserCorrectly()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             bool didLaunchBrowser = false;
 
@@ -51,7 +51,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public async void CloseBrowserCorrectly()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             bool didCloseBrowser = false;
 
@@ -73,7 +73,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public async void RequestAccessToken()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             bool didRequestAccessToken = false;
 
@@ -109,7 +109,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public void SuccessfullyGetAccessToken()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             HttpMessageHandlerMock mockHttpClient = new HttpMessageHandlerMock();
             mockHttpClient.Responder = (request) =>
@@ -153,7 +153,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public async void FailOnStateMismatchInInitialRequest()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             client.OnLaunchBrowser = new Action<string>(url =>
             {
@@ -167,7 +167,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public async void FailOnErrorInInitialRequest()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             client.OnLaunchBrowser = new Action<string>(url =>
             {
@@ -181,7 +181,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public async void RaiseAuthenticationFailedEvent()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             client.OnLaunchBrowser = new Action<string>(url =>
             {
@@ -207,7 +207,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public async void FailOnErrorDataInAccessTokenRequest()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             HttpMessageHandlerMock mockHttpClient = new HttpMessageHandlerMock();
             mockHttpClient.Responder = (request) =>
@@ -233,7 +233,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public async void FailGracefullyOnHttpErrorInAccessTokenRequest()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             HttpMessageHandlerMock mockHttpClient = new HttpMessageHandlerMock();
             mockHttpClient.Responder = (request) =>
@@ -275,7 +275,7 @@ namespace Okta.Xamarin.Test
         public async void LaunchBrowserIfAuthenticatedOnSignOut()
         {
             bool? browserLaunched = false;
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
             client.OnLaunchBrowser = (url) => browserLaunched = true;
             client.SignOutOfOktaAsync(new OktaStateManager("testAccessToken", "testTokenType"));
             Assert.True(browserLaunched);
@@ -285,7 +285,7 @@ namespace Okta.Xamarin.Test
         public void NotLaunchBrowserIfNotAuthenticatedOnSignOut()
         {
             bool? browserLaunched = false;
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
             client.OnLaunchBrowser = (url) => browserLaunched = true;
             client.SignOutOfOktaAsync(new OktaStateManager(string.Empty, string.Empty));
             Assert.False(browserLaunched);

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaStateManagerShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaStateManagerShould.cs
@@ -48,5 +48,28 @@ namespace Okta.Xamarin.Test
             testOktaStateManager.Scope.Should().BeNullOrEmpty();
             testOktaStateManager.Expires.Should().BeNull();
         }
+        [Fact]
+        public void CallClientRevokeAccessToken()
+        {
+            string testAccessToken = "test access token";
+            IOidcClient mockClient = Substitute.For<IOidcClient>();
+            OktaStateManager oktaStateManager = new OktaStateManager { Client = mockClient, AccessToken = testAccessToken };
+
+            oktaStateManager.RevokeAsync(TokenKind.AccessToken).Wait();
+
+            mockClient.Received().RevokeAccessTokenAsync(testAccessToken);
+        }
+
+        [Fact]
+        public void CallClientRevokeRefreshToken()
+        {
+            string testRefreshToken = "test refresh token";
+            IOidcClient mockClient = Substitute.For<IOidcClient>();
+            OktaStateManager oktaStateManager = new OktaStateManager { Client = mockClient, RefreshToken = testRefreshToken };
+
+            oktaStateManager.RevokeAsync(TokenKind.RefreshToken).Wait();
+
+            mockClient.Received().RevokeRefreshTokenAsync(testRefreshToken);
+        }
     }
 }


### PR DESCRIPTION
- Added tests to confirm bug
- Updated `OidcClient` implementation to use authorization server id from config

Fixes https://github.com/okta/okta-oidc-xamarin/issues/54