### PR TITLE
OKTA-417977: correct handling of authserver id on  revoke and renew 

### DIFF
--- a/Okta.Xamarin/Okta.Xamarin/IOidcClient.cs
+++ b/Okta.Xamarin/Okta.Xamarin/IOidcClient.cs
@@ -77,7 +77,7 @@ namespace Okta.Xamarin
         /// <param name="accessToken">The access token used for authorization.</param>
         /// <param name="authorizationServerId">The authorization server id or null.</param>
         /// <returns>Task{Dictionary{string, object}}</returns>
-        Task<Dictionary<string, object>> GetUserAsync(string accessToken, string authorizationServerId = "default");
+        Task<Dictionary<string, object>> GetUserAsync(string accessToken, string authorizationServerId = null);
 
         /// <summary>
         /// Gets user information.
@@ -86,7 +86,7 @@ namespace Okta.Xamarin
         /// <param name="accessToken">The access token used for authorization.</param>
         /// <param name="authorizationServerId">The authorization server id or null.</param>
         /// <returns>Task{T}.</returns>
-        Task<T> GetUserAsync<T>(string accessToken, string authorizationServerId = "default");
+        Task<T> GetUserAsync<T>(string accessToken, string authorizationServerId = null);
 
         /// <summary>
         /// Gets user information as a ClaimsPrincipal instance.
@@ -95,7 +95,7 @@ namespace Okta.Xamarin
         /// <param name="accessToken">The access token used for authorization.</param>
         /// <param name="authorizationServerId">The authorization server id or null.</param>
         /// <returns>Task{ClaimsPrincipal}.</returns>
-        Task<ClaimsPrincipal> GetClaimsPincipalAsync(string accessToken, string authorizationServerId = "default");
+        Task<ClaimsPrincipal> GetClaimsPincipalAsync(string accessToken, string authorizationServerId = null);
 
         /// <summary>
         /// Gets information about the state of the specified token.
@@ -111,7 +111,7 @@ namespace Okta.Xamarin
         /// <param name="token">The token to introspect.</param>
         /// <param name="authorizationServerId">The authorization server ID.</param>
         /// <returns>Dictionary{string, object}.</returns>
-        Task<Dictionary<string, object>> IntrospectAsync(TokenKind tokenKind, string token, string authorizationServerId = "default");
+        Task<Dictionary<string, object>> IntrospectAsync(TokenKind tokenKind, string token, string authorizationServerId = null);
 
         /// <summary>
         /// Renews tokens.
@@ -121,6 +121,6 @@ namespace Okta.Xamarin
         /// <param name="refreshIdToken">A value indicating whether to refresh the ID token.</param>
         /// <param name="authorizationServerId">The authorization server id.</param>
         /// <returns>T.</returns>
-        Task<T> RenewAsync<T>(string refreshToken, bool refreshIdToken = false, string authorizationServerId = "default");
+        Task<T> RenewAsync<T>(string refreshToken, bool refreshIdToken = false, string authorizationServerId = null);
     }
 }

--- a/Okta.Xamarin/Okta.Xamarin/IOidcClient.cs
+++ b/Okta.Xamarin/Okta.Xamarin/IOidcClient.cs
@@ -32,6 +32,11 @@ namespace Okta.Xamarin
         OAuthException OAuthException { get; }
 
         /// <summary>
+        /// Gets the authorization server ID.
+        /// </summary>
+        string AuthorizationServerId { get; }
+
+        /// <summary>
         /// The configuration for this client instance.
         /// </summary>
         IOktaConfig Config { get; set; }
@@ -77,7 +82,7 @@ namespace Okta.Xamarin
         /// <param name="accessToken">The access token used for authorization.</param>
         /// <param name="authorizationServerId">The authorization server id or null.</param>
         /// <returns>Task{Dictionary{string, object}}</returns>
-        Task<Dictionary<string, object>> GetUserAsync(string accessToken, string authorizationServerId = null);
+        Task<Dictionary<string, object>> GetUserAsync(string accessToken);
 
         /// <summary>
         /// Gets user information.
@@ -86,7 +91,7 @@ namespace Okta.Xamarin
         /// <param name="accessToken">The access token used for authorization.</param>
         /// <param name="authorizationServerId">The authorization server id or null.</param>
         /// <returns>Task{T}.</returns>
-        Task<T> GetUserAsync<T>(string accessToken, string authorizationServerId = null);
+        Task<T> GetUserAsync<T>(string accessToken);
 
         /// <summary>
         /// Gets user information as a ClaimsPrincipal instance.
@@ -95,7 +100,7 @@ namespace Okta.Xamarin
         /// <param name="accessToken">The access token used for authorization.</param>
         /// <param name="authorizationServerId">The authorization server id or null.</param>
         /// <returns>Task{ClaimsPrincipal}.</returns>
-        Task<ClaimsPrincipal> GetClaimsPincipalAsync(string accessToken, string authorizationServerId = null);
+        Task<ClaimsPrincipal> GetClaimsPincipalAsync(string accessToken);
 
         /// <summary>
         /// Gets information about the state of the specified token.
@@ -111,7 +116,7 @@ namespace Okta.Xamarin
         /// <param name="token">The token to introspect.</param>
         /// <param name="authorizationServerId">The authorization server ID.</param>
         /// <returns>Dictionary{string, object}.</returns>
-        Task<Dictionary<string, object>> IntrospectAsync(TokenKind tokenKind, string token, string authorizationServerId = null);
+        Task<Dictionary<string, object>> IntrospectAsync(TokenKind tokenKind, string token);
 
         /// <summary>
         /// Renews tokens.
@@ -121,6 +126,6 @@ namespace Okta.Xamarin
         /// <param name="refreshIdToken">A value indicating whether to refresh the ID token.</param>
         /// <param name="authorizationServerId">The authorization server id.</param>
         /// <returns>T.</returns>
-        Task<T> RenewAsync<T>(string refreshToken, bool refreshIdToken = false, string authorizationServerId = null);
+        Task<T> RenewAsync<T>(string refreshToken, bool refreshIdToken = false);
     }
 }

--- a/Okta.Xamarin/Okta.Xamarin/IOktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/IOktaStateManager.cs
@@ -169,6 +169,28 @@ namespace Okta.Xamarin
         Task RevokeAsync(TokenKind tokenKind);
 
         /// <summary>
+        /// Revoke the specified token.
+        /// </summary>
+        /// <param name="tokenKind">The kind of the token.</param>
+        /// <param name="token">The token.</param>
+        /// <returns>Task.</returns>
+        Task RevokeAsync(TokenKind tokenKind, string token);
+
+        /// <summary>
+        /// Revoke the specified access token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <returns>Task.</returns>
+        Task RevokeAccessTokenAsync(string token);
+
+        /// <summary>
+        /// Revoke the specified refresh token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <returns>Task.</returns>
+        Task RevokeRefreshTokenAsync(string token);
+
+        /// <summary>
         /// Stores the tokens securely in platform-specific secure storage.
         /// Subscribe to SecureStorageWriteException event for exception details
         /// if an exception occurs, see event <see cref="SecureStorageWriteException"/>.

--- a/Okta.Xamarin/Okta.Xamarin/IOktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/IOktaStateManager.cs
@@ -120,21 +120,21 @@ namespace Okta.Xamarin
         /// <typeparam name="T">The type to deserialize the response as.</typeparam>
         /// <param name="authorizationServerId">The authorization server ID.</param>
         /// <returns>T.</returns>
-        Task<T> GetUserAsync<T>(string authorizationServerId = "default");
+        Task<T> GetUserAsync<T>(string authorizationServerId = null);
 
         /// <summary>
         /// Gets information about the current user.
         /// </summary>
         /// <param name="authorizationServerId">The authorization server ID.</param>
         /// <returns>Dictionary{string, object}.</returns>
-        Task<Dictionary<string, object>> GetUserAsync(string authorizationServerId = "default");
+        Task<Dictionary<string, object>> GetUserAsync(string authorizationServerId = null);
 
         /// <summary>
         /// Gets information about the current user as a ClaimsPrincipal.
         /// </summary>
         /// <param name="authorizationServerId">The authorization server ID.</param>
         /// <returns>ClaimsPrincipal.</returns>
-        Task<ClaimsPrincipal> GetClaimsPrincipalAsync(string authorizationServerId = "default");
+        Task<ClaimsPrincipal> GetClaimsPrincipalAsync(string authorizationServerId = null);
 
         /// <summary>
         /// Gets information about the state of the specified token.
@@ -142,7 +142,7 @@ namespace Okta.Xamarin
         /// <param name="tokenKind">The kind of token.</param>
         /// <param name="authorizationServerId">The authorization server ID.</param>
         /// <returns>Dictoinary{string, object}.</returns>
-        Task<Dictionary<string, object>> IntrospectAsync(TokenKind tokenKind, string authorizationServerId = "default");
+        Task<Dictionary<string, object>> IntrospectAsync(TokenKind tokenKind, string authorizationServerId = null);
 
         /// <summary>
         /// Renews tokens.
@@ -150,7 +150,7 @@ namespace Okta.Xamarin
         /// <param name="refreshIdToken">A value indicating whether to also renew the ID token.</param>
         /// <param name="authorizationServerId">The authorization server ID.</param>
         /// <returns>Task{RenewResponse}.</returns>
-        Task<RenewResponse> RenewAsync(bool refreshIdToken = false, string authorizationServerId = "default");
+        Task<RenewResponse> RenewAsync(bool refreshIdToken = false, string authorizationServerId = null);
 
         /// <summary>
         /// Renews tokens.
@@ -159,7 +159,7 @@ namespace Okta.Xamarin
         /// <param name="refreshIdToken">A value indicating whether to refresh the ID token.</param>
         /// <param name="authorizationServerId">The authorization server.</param>
         /// <returns>Task{RenewResponse}.</returns>
-        Task<RenewResponse> RenewAsync(string refreshToken, bool refreshIdToken = false, string authorizationServerId = "default");
+        Task<RenewResponse> RenewAsync(string refreshToken, bool refreshIdToken = false, string authorizationServerId = null);
 
         /// <summary>
         /// Revokes tokens associated with this OktaState.

--- a/Okta.Xamarin/Okta.Xamarin/IOktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/IOktaStateManager.cs
@@ -114,52 +114,49 @@ namespace Okta.Xamarin
         /// <returns>string.</returns>
         string GetToken(TokenKind tokenKind);
 
-		/// <summary>
-		/// Gets an instance of the generic type T representing the current user.
-		/// </summary>
-		/// <typeparam name="T">The type to deserialize the response as.</typeparam>
-		/// <param name="authorizationServerId">The authorization server ID.</param>
-		/// <returns>T.</returns>
-		Task<T> GetUserAsync<T>();// string authorizationServerId = null);
+        /// <summary>
+        /// Gets an instance of the generic type T representing the current user.
+        /// </summary>
+        /// <typeparam name="T">The type to deserialize the response as.</typeparam>
+        /// <param name="authorizationServerId">The authorization server ID.</param>
+        /// <returns>T.</returns>
+        Task<T> GetUserAsync<T>();
 
-		/// <summary>
-		/// Gets information about the current user.
-		/// </summary>
-		/// <param name="authorizationServerId">The authorization server ID.</param>
-		/// <returns>Dictionary{string, object}.</returns>
-		Task<Dictionary<string, object>> GetUserAsync();// string authorizationServerId = null);
+        /// <summary>
+        /// Gets information about the current user.
+        /// </summary>
+        /// <param name="authorizationServerId">The authorization server ID.</param>
+        /// <returns>Dictionary{string, object}.</returns>
+        Task<Dictionary<string, object>> GetUserAsync();
 
-		/// <summary>
-		/// Gets information about the current user as a ClaimsPrincipal.
-		/// </summary>
-		/// <param name="authorizationServerId">The authorization server ID.</param>
-		/// <returns>ClaimsPrincipal.</returns>
-		Task<ClaimsPrincipal> GetClaimsPrincipalAsync();// string authorizationServerId = null);
+        /// <summary>
+        /// Gets information about the current user as a ClaimsPrincipal.
+        /// </summary>
+        /// <param name="authorizationServerId">The authorization server ID.</param>
+        /// <returns>ClaimsPrincipal.</returns>
+        Task<ClaimsPrincipal> GetClaimsPrincipalAsync();
 
-		/// <summary>
-		/// Gets information about the state of the specified token.
-		/// </summary>
-		/// <param name="tokenKind">The kind of token.</param>
-		/// <param name="authorizationServerId">The authorization server ID.</param>
-		/// <returns>Dictoinary{string, object}.</returns>
-		Task<Dictionary<string, object>> IntrospectAsync(TokenKind tokenKind);//, string authorizationServerId = null);
+        /// <summary>
+        /// Gets information about the state of the specified token.
+        /// </summary>
+        /// <param name="tokenKind">The kind of token.</param>
+        /// <returns>Dictoinary{string, object}.</returns>
+        Task<Dictionary<string, object>> IntrospectAsync(TokenKind tokenKind);
 
-		/// <summary>
-		/// Renews tokens.
-		/// </summary>
-		/// <param name="refreshIdToken">A value indicating whether to also renew the ID token.</param>
-		/// <param name="authorizationServerId">The authorization server ID.</param>
-		/// <returns>Task{RenewResponse}.</returns>
-		Task<RenewResponse> RenewAsync(bool refreshIdToken = false);//, string authorizationServerId = null);
+        /// <summary>
+        /// Renews tokens.
+        /// </summary>
+        /// <param name="refreshIdToken">A value indicating whether to also renew the ID token.</param>
+        /// <returns>Task{RenewResponse}.</returns>
+        Task<RenewResponse> RenewAsync(bool refreshIdToken = false);
 
-		/// <summary>
-		/// Renews tokens.
-		/// </summary>
-		/// <param name="refreshToken">The refresh token.</param>
-		/// <param name="refreshIdToken">A value indicating whether to refresh the ID token.</param>
-		/// <param name="authorizationServerId">The authorization server.</param>
-		/// <returns>Task{RenewResponse}.</returns>
-		Task<RenewResponse> RenewAsync(string refreshToken, bool refreshIdToken = false);//, string authorizationServerId = null);
+        /// <summary>
+        /// Renews tokens.
+        /// </summary>
+        /// <param name="refreshToken">The refresh token.</param>
+        /// <param name="refreshIdToken">A value indicating whether to refresh the ID token.</param>
+        /// <returns>Task{RenewResponse}.</returns>
+        Task<RenewResponse> RenewAsync(string refreshToken, bool refreshIdToken = false);
 
         /// <summary>
         /// Revokes tokens associated with this OktaState.

--- a/Okta.Xamarin/Okta.Xamarin/IOktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/IOktaStateManager.cs
@@ -114,52 +114,52 @@ namespace Okta.Xamarin
         /// <returns>string.</returns>
         string GetToken(TokenKind tokenKind);
 
-        /// <summary>
-        /// Gets an instance of the generic type T representing the current user.
-        /// </summary>
-        /// <typeparam name="T">The type to deserialize the response as.</typeparam>
-        /// <param name="authorizationServerId">The authorization server ID.</param>
-        /// <returns>T.</returns>
-        Task<T> GetUserAsync<T>(string authorizationServerId = null);
+		/// <summary>
+		/// Gets an instance of the generic type T representing the current user.
+		/// </summary>
+		/// <typeparam name="T">The type to deserialize the response as.</typeparam>
+		/// <param name="authorizationServerId">The authorization server ID.</param>
+		/// <returns>T.</returns>
+		Task<T> GetUserAsync<T>();// string authorizationServerId = null);
 
-        /// <summary>
-        /// Gets information about the current user.
-        /// </summary>
-        /// <param name="authorizationServerId">The authorization server ID.</param>
-        /// <returns>Dictionary{string, object}.</returns>
-        Task<Dictionary<string, object>> GetUserAsync(string authorizationServerId = null);
+		/// <summary>
+		/// Gets information about the current user.
+		/// </summary>
+		/// <param name="authorizationServerId">The authorization server ID.</param>
+		/// <returns>Dictionary{string, object}.</returns>
+		Task<Dictionary<string, object>> GetUserAsync();// string authorizationServerId = null);
 
-        /// <summary>
-        /// Gets information about the current user as a ClaimsPrincipal.
-        /// </summary>
-        /// <param name="authorizationServerId">The authorization server ID.</param>
-        /// <returns>ClaimsPrincipal.</returns>
-        Task<ClaimsPrincipal> GetClaimsPrincipalAsync(string authorizationServerId = null);
+		/// <summary>
+		/// Gets information about the current user as a ClaimsPrincipal.
+		/// </summary>
+		/// <param name="authorizationServerId">The authorization server ID.</param>
+		/// <returns>ClaimsPrincipal.</returns>
+		Task<ClaimsPrincipal> GetClaimsPrincipalAsync();// string authorizationServerId = null);
 
-        /// <summary>
-        /// Gets information about the state of the specified token.
-        /// </summary>
-        /// <param name="tokenKind">The kind of token.</param>
-        /// <param name="authorizationServerId">The authorization server ID.</param>
-        /// <returns>Dictoinary{string, object}.</returns>
-        Task<Dictionary<string, object>> IntrospectAsync(TokenKind tokenKind, string authorizationServerId = null);
+		/// <summary>
+		/// Gets information about the state of the specified token.
+		/// </summary>
+		/// <param name="tokenKind">The kind of token.</param>
+		/// <param name="authorizationServerId">The authorization server ID.</param>
+		/// <returns>Dictoinary{string, object}.</returns>
+		Task<Dictionary<string, object>> IntrospectAsync(TokenKind tokenKind);//, string authorizationServerId = null);
 
-        /// <summary>
-        /// Renews tokens.
-        /// </summary>
-        /// <param name="refreshIdToken">A value indicating whether to also renew the ID token.</param>
-        /// <param name="authorizationServerId">The authorization server ID.</param>
-        /// <returns>Task{RenewResponse}.</returns>
-        Task<RenewResponse> RenewAsync(bool refreshIdToken = false, string authorizationServerId = null);
+		/// <summary>
+		/// Renews tokens.
+		/// </summary>
+		/// <param name="refreshIdToken">A value indicating whether to also renew the ID token.</param>
+		/// <param name="authorizationServerId">The authorization server ID.</param>
+		/// <returns>Task{RenewResponse}.</returns>
+		Task<RenewResponse> RenewAsync(bool refreshIdToken = false);//, string authorizationServerId = null);
 
-        /// <summary>
-        /// Renews tokens.
-        /// </summary>
-        /// <param name="refreshToken">The refresh token.</param>
-        /// <param name="refreshIdToken">A value indicating whether to refresh the ID token.</param>
-        /// <param name="authorizationServerId">The authorization server.</param>
-        /// <returns>Task{RenewResponse}.</returns>
-        Task<RenewResponse> RenewAsync(string refreshToken, bool refreshIdToken = false, string authorizationServerId = null);
+		/// <summary>
+		/// Renews tokens.
+		/// </summary>
+		/// <param name="refreshToken">The refresh token.</param>
+		/// <param name="refreshIdToken">A value indicating whether to refresh the ID token.</param>
+		/// <param name="authorizationServerId">The authorization server.</param>
+		/// <returns>Task{RenewResponse}.</returns>
+		Task<RenewResponse> RenewAsync(string refreshToken, bool refreshIdToken = false);//, string authorizationServerId = null);
 
         /// <summary>
         /// Revokes tokens associated with this OktaState.

--- a/Okta.Xamarin/Okta.Xamarin/IntrospectOptions.cs
+++ b/Okta.Xamarin/Okta.Xamarin/IntrospectOptions.cs
@@ -15,7 +15,7 @@ namespace Okta.Xamarin
         /// </summary>
         public IntrospectOptions()
         {
-            AuthorizationServerId = "default";
+            //AuthorizationServerId = "default";
         }
 
         /// <summary>
@@ -31,6 +31,6 @@ namespace Okta.Xamarin
         /// <summary>
         /// Gets or sets the authorization server id.
         /// </summary>
-        public string AuthorizationServerId { get; set; }
+        //public string AuthorizationServerId { get; set; }
     }
 }

--- a/Okta.Xamarin/Okta.Xamarin/IntrospectOptions.cs
+++ b/Okta.Xamarin/Okta.Xamarin/IntrospectOptions.cs
@@ -15,7 +15,6 @@ namespace Okta.Xamarin
         /// </summary>
         public IntrospectOptions()
         {
-            //AuthorizationServerId = "default";
         }
 
         /// <summary>
@@ -27,10 +26,5 @@ namespace Okta.Xamarin
         /// Gets or sets the kind of the target token.
         /// </summary>
         public TokenKind TokenKind { get; set; }
-
-        /// <summary>
-        /// Gets or sets the authorization server id.
-        /// </summary>
-        //public string AuthorizationServerId { get; set; }
     }
 }

--- a/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
@@ -342,7 +342,7 @@ namespace Okta.Xamarin
         protected virtual string GetAuthorizationServerBasePath(string authorizationServerId = null)
         {
             string domain = Config?.OktaDomain;
-            if (domain.EndsWith("/"))
+            if ((bool)domain?.EndsWith("/"))
             {
                 domain = domain.Substring(0, domain.Length - 1);
             }

--- a/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
@@ -151,11 +151,11 @@ namespace Okta.Xamarin
         /// <summary>
         /// Gets introspection details.
         /// </summary>
-        /// <param name="options">IntrospectionOptions</param>
+        /// <param name="options">IntrospectionOptions.</param>
         /// <returns>Dicationary{string, object}.</returns>
         public async Task<Dictionary<string, object>> IntrospectAsync(IntrospectOptions options)
         {
-            return await IntrospectAsync(options.TokenKind, options.Token);//, options.AuthorizationServerId);
+            return await IntrospectAsync(options.TokenKind, options.Token);
         }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace Okta.Xamarin
                     break;
             }
 
-            return await IntrospectAsync(token, tokenHint);//, authorizationServerId);
+            return await IntrospectAsync(token, tokenHint);
         }
 
         /// <summary>
@@ -193,9 +193,9 @@ namespace Okta.Xamarin
         /// <param name="accessToken">The access token used to authorize the request.</param>
         /// <param name="authorizationServerId">The authorization server id.</param>
         /// <returns>Dictionary{string, object}.</returns>
-        public async Task<Dictionary<string, object>> GetUserAsync(string accessToken)//, string authorizationServerId = null)
+        public async Task<Dictionary<string, object>> GetUserAsync(string accessToken)
         {
-            return await GetUserAsync<Dictionary<string, object>>(accessToken);//, authorizationServerId);
+            return await GetUserAsync<Dictionary<string, object>>(accessToken);
         }
 
         /// <summary>
@@ -205,9 +205,9 @@ namespace Okta.Xamarin
         /// <param name="accessToken">The access token used to authorize the request.</param>
         /// <param name="authorizationServerId">The authorization server id.</param>
         /// <returns>T.</returns>
-        public async Task<T> GetUserAsync<T>(string accessToken)//, string authorizationServerId = null)
+        public async Task<T> GetUserAsync<T>(string accessToken)
         {
-            string userInfoJson = await GetUserInfoJsonAsync(accessToken);//, authorizationServerId);
+            string userInfoJson = await GetUserInfoJsonAsync(accessToken);
             return JsonConvert.DeserializeObject<T>(userInfoJson);
         }
 
@@ -217,9 +217,9 @@ namespace Okta.Xamarin
         /// <param name="accessToken">The access token used to authorize the request.</param>
         /// <param name="authorizationServerId">The authorization server id.</param>
         /// <returns>ClaimsPrincipal</returns>
-        public async Task<ClaimsPrincipal> GetClaimsPincipalAsync(string accessToken)//, string authorizationServerId = null)
+        public async Task<ClaimsPrincipal> GetClaimsPincipalAsync(string accessToken)
         {
-            string userInfoJson = await GetUserInfoJsonAsync(accessToken);//, authorizationServerId);
+            string userInfoJson = await GetUserInfoJsonAsync(accessToken);
 
             UserInfo userInfo = JsonConvert.DeserializeObject<UserInfo>(userInfoJson); // OKTA-371439 added to ensure proper mapping of all claims to ClaimsPrincipal
 
@@ -236,13 +236,13 @@ namespace Okta.Xamarin
         /// <param name="refreshIdToken">A value indicating whether the id token should be refreshed.</param>
         /// <param name="authorizationServerId">The authorization server id.</param>
         /// <returns>T.</returns>
-        public async Task<T> RenewAsync<T>(string refreshToken, bool refreshIdToken = false)//, string authorizationServerId = null)
+        public async Task<T> RenewAsync<T>(string refreshToken, bool refreshIdToken = false)
         {
-            string responseJson = await GetRenewJsonAsync(refreshToken, refreshIdToken);//, authorizationServerId);
+            string responseJson = await GetRenewJsonAsync(refreshToken, refreshIdToken);
             return JsonConvert.DeserializeObject<T>(responseJson);
         }
 
-        protected async Task<string> GetRenewJsonAsync(string refreshToken, bool refreshIdToken = false)//, string authorizationServerId = null)
+        protected async Task<string> GetRenewJsonAsync(string refreshToken, bool refreshIdToken = false)
         {
             // for details see: https://developer.okta.com/docs/guides/refresh-tokens/use-refresh-token/
             string scope = "offline_access";
@@ -257,30 +257,30 @@ namespace Okta.Xamarin
                 { "redirect_uri", Config.RedirectUri },
                 { "scope", scope },
                 { "refresh_token", refreshToken },
-            });//, authorizationServerId);
+            });
         }
 
-        protected async Task<string> GetIntrospectJsonAsync(string token, string tokenTypeHint)//, string authorizationServerId = null)
+        protected async Task<string> GetIntrospectJsonAsync(string token, string tokenTypeHint)
         {
             return await PerformAuthorizationServerRequestAsync(HttpMethod.Post, $"/introspect?client_id={Config.ClientId}", new Dictionary<string, string>(), new Dictionary<string, string>
             {
                 { "token", token },
                 { "token_type_hint", tokenTypeHint },
-            });//, authorizationServerId);
+            });
         }
 
-        protected async Task<Dictionary<string, object>> IntrospectAsync(string token, string tokenTypeHint)//, string authorizationServerId = null)
+        protected async Task<Dictionary<string, object>> IntrospectAsync(string token, string tokenTypeHint)
         {
-            string responseJson = await GetIntrospectJsonAsync(token, tokenTypeHint);//, authorizationServerId);
+            string responseJson = await GetIntrospectJsonAsync(token, tokenTypeHint);
             return JsonConvert.DeserializeObject<Dictionary<string, object>>(responseJson);
         }
 
-        protected async Task<string> GetUserInfoJsonAsync(string accessToken)//, string authorizationServerId = null)
+        protected async Task<string> GetUserInfoJsonAsync(string accessToken)
         {
             return await PerformAuthorizationServerRequestAsync(HttpMethod.Get, "/userinfo", new Dictionary<string, string>
             {
                 {"Authorization", $"Bearer {accessToken}" }
-            });//, authorizationServerId);
+            });
         }
 
         protected async Task<string> PerformRequestAsync(HttpMethod httpMethod, string path, Dictionary<string, string> headers)
@@ -314,17 +314,15 @@ namespace Okta.Xamarin
             return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         }
 
-        protected virtual async Task<string> PerformAuthorizationServerRequestAsync(HttpMethod httpMethod, string path, Dictionary<string, string> headers, Dictionary<string, string> formUrlEncodedContent)//, string authorizationServerId = null)
+        protected virtual async Task<string> PerformAuthorizationServerRequestAsync(HttpMethod httpMethod, string path, Dictionary<string, string> headers, Dictionary<string, string> formUrlEncodedContent)
         {
-            return await PerformAuthorizationServerRequestAsync(httpMethod, path, headers, /* authorizationServerId, */ formUrlEncodedContent.ToArray());
+            return await PerformAuthorizationServerRequestAsync(httpMethod, path, headers, formUrlEncodedContent.ToArray());
         }
 
-        protected virtual async Task<string> PerformAuthorizationServerRequestAsync(HttpMethod httpMethod, string path, Dictionary<string, string> headers, /*string authorizationServerId = null,*/ params KeyValuePair<string, string>[] formUrlEncodedContent)
+        protected virtual async Task<string> PerformAuthorizationServerRequestAsync(HttpMethod httpMethod, string path, Dictionary<string, string> headers, params KeyValuePair<string, string>[] formUrlEncodedContent)
         {
             try
             {
-                //authorizationServerId = authorizationServerId ?? this.Config.AuthorizationServerId ?? "default";
-
                 FormUrlEncodedContent content = null;
                 if ((bool)formUrlEncodedContent?.Any())
                 {
@@ -366,7 +364,7 @@ namespace Okta.Xamarin
             return $"{Config?.OktaDomain}/oauth2/v1";
         }
 
-        protected virtual string GetAuthorizationServerBasePath()//string authorizationServerId = null)
+        protected virtual string GetAuthorizationServerBasePath()
         {
             string domain = Config?.OktaDomain;
             if ((bool)domain?.EndsWith("/"))

--- a/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
@@ -367,6 +367,11 @@ namespace Okta.Xamarin
         protected virtual string GetAuthorizationServerBasePath()
         {
             string domain = Config?.OktaDomain;
+            if (string.IsNullOrEmpty(AuthorizationServerId))
+            {
+                return domain;
+            }
+
             if ((bool)domain?.EndsWith("/"))
             {
                 domain = domain.Substring(0, domain.Length - 1);

--- a/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
@@ -784,46 +784,23 @@ namespace Okta.Xamarin
         /// <summary>
         /// Renew tokens.
         /// </summary>
-        /// <param name="refreshToken">The refresh token.  The default is StateManager.RefreshToken.</param>
-        /// <param name="refreshIdToken">A value indicating whether to renew the ID token, the default is false.</param>
-        /// <returns>A <see cref="Task{RenewResponse}"/> representing the result of the asynchronous operation.</returns>
-/*        public static async Task<RenewResponse> RenewAsync(string refreshToken = null, bool refreshIdToken = false)
-        {
-            return await Current.RenewAsync(refreshToken, refreshIdToken);
-        }*/
-
-        /// <summary>
-        /// Renew tokens.
-        /// </summary>
-        /// <param name="refreshIdToken">A value indicating whether to renew the ID token, the default is false.</param>
-        /// <param name="authorizationServerId">The authorization server id.</param>
-        /// <returns>A <see cref="Task{RenewResponse}"/> representing the result of the asynchronous operation.</returns>
-/*        public virtual async Task<RenewResponse> RenewAsync(bool refreshIdToken = false)//, string authorizationServerId = null)
-        {
-            return await this.RenewAsync(RefreshToken, refreshIdToken);//, authorizationServerId);
-        }*/
-
-        /// <summary>
-        /// Renew tokens.
-        /// </summary>
         /// <param name="refreshToken">The refresh token.</param>
         /// <param name="refreshIdToken">A value indicating whether to renew the ID token, the default is false.</param>
-        /// <param name="authorizationServerId">The authorization server id.</param>
         /// <returns>A <see cref="Task{RenewResponse}"/> representing the result of the asynchronous operation.</returns>
-        public virtual async Task<RenewResponse> RenewAsync(string refreshToken = null, bool refreshIdToken = false)//, string authorizationServerId = null)
+        public virtual async Task<RenewResponse> RenewAsync(string refreshToken = null, bool refreshIdToken = false)
         {
             try
             {
                 refreshToken = refreshToken ?? this.StateManager?.RefreshToken;
-				if (string.IsNullOrEmpty(refreshToken))
-				{
-					throw new ArgumentNullException(nameof(refreshToken));
-				}
+                if (string.IsNullOrEmpty(refreshToken))
+                {
+                    throw new ArgumentNullException(nameof(refreshToken));
+                }
 
                 string authorizationServerId = this.StateManager?.Config?.AuthorizationServerId;
 
                 this.RenewStarted?.Invoke(this, new RenewEventArgs { StateManager = this.StateManager, RefreshToken = refreshToken, RefreshIdToken = refreshIdToken, AuthorizationServerId = authorizationServerId });
-                RenewResponse result = await this.StateManager.RenewAsync(refreshToken, refreshIdToken);//, authorizationServerId);
+                RenewResponse result = await this.StateManager.RenewAsync(refreshToken, refreshIdToken);
                 this.RenewCompleted?.Invoke(this, new RenewEventArgs { StateManager = this.StateManager, RefreshToken = refreshToken, Response = result, RefreshIdToken = refreshIdToken, AuthorizationServerId = authorizationServerId });
 
                 return result;
@@ -851,6 +828,7 @@ namespace Okta.Xamarin
         /// <summary>
         /// Gets information about the current user.
         /// </summary>
+        /// <returns>Task{Dictionary{string,object}}.</returns>
         public virtual async Task<Dictionary<string, object>> GetUserAsync()
         {
             this.GetUserStarted?.Invoke(this, new GetUserEventArgs { StateManager = this.StateManager });

--- a/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
@@ -604,6 +604,15 @@ namespace Okta.Xamarin
         }
 
         /// <summary>
+        /// Convenience method to add a listener to the OktaContext.Current.RenewException event.
+        /// </summary>
+        /// <param name="renewExceptionEventHandler">The event handler.</param>
+        public static void AddRenewExceptionListener(EventHandler<RenewExceptionEventArgs> renewExceptionEventHandler)
+        {
+            Current.RenewException += renewExceptionEventHandler;
+        }
+
+        /// <summary>
         /// Initialize OktaContext.Current services with the implementations in the specified inversion of control container.
         /// </summary>
         /// <param name="iocContainer">The inversion of control container.</param>
@@ -728,6 +737,17 @@ namespace Okta.Xamarin
             {
                 token = token ?? this.StateManager.GetToken(tokenKind);
                 this.RevokeStarted?.Invoke(this, new RevokeEventArgs { StateManager = this.StateManager, TokenKind = tokenKind, Token = token });
+
+                switch (tokenKind)
+                {
+                    case Xamarin.TokenKind.AccessToken:
+                        await this.StateManager.RevokeAccessTokenAsync(token);
+                        break;
+                    case Xamarin.TokenKind.RefreshToken:
+                    default:
+                        await this.StateManager.RevokeRefreshTokenAsync(token);
+                        break;
+                }
 
                 await this.StateManager.RevokeAsync(tokenKind);
 

--- a/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
@@ -749,8 +749,6 @@ namespace Okta.Xamarin
                         break;
                 }
 
-                await this.StateManager.RevokeAsync(tokenKind);
-
                 this.RevokeCompleted?.Invoke(this, new RevokeEventArgs { StateManager = this.StateManager, TokenKind = tokenKind, Response = this.StateManager.LastApiResponse });
             }
             catch (Exception ex)

--- a/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
@@ -778,7 +778,7 @@ namespace Okta.Xamarin
         /// <returns>A <see cref="Task{RenewResponse}"/> representing the result of the asynchronous operation.</returns>
         public static async Task<RenewResponse> RenewAsync(bool refreshIdToken)
         {
-            return await RenewAsync(RefreshToken, refreshIdToken);
+            return await Current.RenewAsync(RefreshToken, refreshIdToken);
         }
 
         /// <summary>
@@ -787,10 +787,10 @@ namespace Okta.Xamarin
         /// <param name="refreshToken">The refresh token.  The default is StateManager.RefreshToken.</param>
         /// <param name="refreshIdToken">A value indicating whether to renew the ID token, the default is false.</param>
         /// <returns>A <see cref="Task{RenewResponse}"/> representing the result of the asynchronous operation.</returns>
-        public static async Task<RenewResponse> RenewAsync(string refreshToken = null, bool refreshIdToken = false)
+/*        public static async Task<RenewResponse> RenewAsync(string refreshToken = null, bool refreshIdToken = false)
         {
             return await Current.RenewAsync(refreshToken, refreshIdToken);
-        }
+        }*/
 
         /// <summary>
         /// Renew tokens.
@@ -798,10 +798,10 @@ namespace Okta.Xamarin
         /// <param name="refreshIdToken">A value indicating whether to renew the ID token, the default is false.</param>
         /// <param name="authorizationServerId">The authorization server id.</param>
         /// <returns>A <see cref="Task{RenewResponse}"/> representing the result of the asynchronous operation.</returns>
-        public virtual async Task<RenewResponse> RenewAsync(bool refreshIdToken = false, string authorizationServerId = null)
+/*        public virtual async Task<RenewResponse> RenewAsync(bool refreshIdToken = false)//, string authorizationServerId = null)
         {
-            return await this.RenewAsync(RefreshToken, refreshIdToken, authorizationServerId);
-        }
+            return await this.RenewAsync(RefreshToken, refreshIdToken);//, authorizationServerId);
+        }*/
 
         /// <summary>
         /// Renew tokens.
@@ -810,12 +810,20 @@ namespace Okta.Xamarin
         /// <param name="refreshIdToken">A value indicating whether to renew the ID token, the default is false.</param>
         /// <param name="authorizationServerId">The authorization server id.</param>
         /// <returns>A <see cref="Task{RenewResponse}"/> representing the result of the asynchronous operation.</returns>
-        public virtual async Task<RenewResponse> RenewAsync(string refreshToken, bool refreshIdToken = false, string authorizationServerId = null)
+        public virtual async Task<RenewResponse> RenewAsync(string refreshToken = null, bool refreshIdToken = false)//, string authorizationServerId = null)
         {
             try
             {
+                refreshToken = refreshToken ?? this.StateManager?.RefreshToken;
+				if (string.IsNullOrEmpty(refreshToken))
+				{
+					throw new ArgumentNullException(nameof(refreshToken));
+				}
+
+                string authorizationServerId = this.StateManager?.Config?.AuthorizationServerId;
+
                 this.RenewStarted?.Invoke(this, new RenewEventArgs { StateManager = this.StateManager, RefreshToken = refreshToken, RefreshIdToken = refreshIdToken, AuthorizationServerId = authorizationServerId });
-                RenewResponse result = await this.StateManager.RenewAsync(refreshIdToken, authorizationServerId);
+                RenewResponse result = await this.StateManager.RenewAsync(refreshToken, refreshIdToken);//, authorizationServerId);
                 this.RenewCompleted?.Invoke(this, new RenewEventArgs { StateManager = this.StateManager, RefreshToken = refreshToken, Response = result, RefreshIdToken = refreshIdToken, AuthorizationServerId = authorizationServerId });
 
                 return result;

--- a/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
@@ -339,7 +339,6 @@ namespace Okta.Xamarin
             {
                 Token = this.GetToken(tokenKind),
                 TokenKind = tokenKind,
-                // AuthorizationServerId = authorizationServerId,
             });
         }
 

--- a/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
@@ -294,19 +294,19 @@ namespace Okta.Xamarin
         }
 
         /// <inheritdoc/>
-        public async Task<T> GetUserAsync<T>(string authorizationServerId = "default")
+        public async Task<T> GetUserAsync<T>(string authorizationServerId = null)
         {
             return await this.Client.GetUserAsync<T>(this.AccessToken, authorizationServerId);
         }
 
         /// <inheritdoc/>
-        public async Task<Dictionary<string, object>> GetUserAsync(string authorizationServerId = "default")
+        public async Task<Dictionary<string, object>> GetUserAsync(string authorizationServerId = null)
         {
             return await this.Client.GetUserAsync(this.AccessToken, authorizationServerId);
         }
 
         /// <inheritdoc/>
-        public async Task<Dictionary<string, object>> IntrospectAsync(TokenKind tokenKind, string authorizationServerId = "default")
+        public async Task<Dictionary<string, object>> IntrospectAsync(TokenKind tokenKind, string authorizationServerId = null)
         {
             return await this.Client.IntrospectAsync(new IntrospectOptions
             {
@@ -317,19 +317,19 @@ namespace Okta.Xamarin
         }
 
         /// <inheritdoc/>
-        public async Task<ClaimsPrincipal> GetClaimsPrincipalAsync(string authorizationServerId = "default")
+        public async Task<ClaimsPrincipal> GetClaimsPrincipalAsync(string authorizationServerId = null)
         {
             return await this.Client.GetClaimsPincipalAsync(this.AccessToken, authorizationServerId);
         }
 
         /// <inheritdoc/>
-        public async Task<RenewResponse> RenewAsync(bool refreshIdToken = false, string authorizationServerId = "default")
+        public async Task<RenewResponse> RenewAsync(bool refreshIdToken = false, string authorizationServerId = null)
         {
             return await this.RenewAsync(this.RefreshToken, refreshIdToken, authorizationServerId);
         }
 
         /// <inheritdoc/>
-        public async Task<RenewResponse> RenewAsync(string refreshToken, bool refreshIdToken = false, string authorizationServerId = "default")
+        public async Task<RenewResponse> RenewAsync(string refreshToken, bool refreshIdToken = false, string authorizationServerId = null)
         {
             RenewResponse renewResponse = await this.Client.RenewAsync<RenewResponse>(refreshToken, refreshIdToken, authorizationServerId);
             this.RenewResponse = renewResponse;

--- a/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
@@ -321,19 +321,19 @@ namespace Okta.Xamarin
         }
 
         /// <inheritdoc/>
-        public async Task<T> GetUserAsync<T>()//string authorizationServerId = null)
+        public async Task<T> GetUserAsync<T>()
         {
-			return await this.Client.GetUserAsync<T>(this.AccessToken);//, authorizationServerId);
+            return await this.Client.GetUserAsync<T>(this.AccessToken);
         }
 
         /// <inheritdoc/>
-        public async Task<Dictionary<string, object>> GetUserAsync()//string authorizationServerId = null)
+        public async Task<Dictionary<string, object>> GetUserAsync()
         {
-			return await this.Client.GetUserAsync(this.AccessToken);//, authorizationServerId);
+            return await this.Client.GetUserAsync(this.AccessToken);
         }
 
         /// <inheritdoc/>
-        public async Task<Dictionary<string, object>> IntrospectAsync(TokenKind tokenKind)//, string authorizationServerId = null)
+        public async Task<Dictionary<string, object>> IntrospectAsync(TokenKind tokenKind)
         {
             return await this.Client.IntrospectAsync(new IntrospectOptions
             {
@@ -344,21 +344,21 @@ namespace Okta.Xamarin
         }
 
         /// <inheritdoc/>
-        public async Task<ClaimsPrincipal> GetClaimsPrincipalAsync()//string authorizationServerId = null)
+        public async Task<ClaimsPrincipal> GetClaimsPrincipalAsync()
         {
-			return await this.Client.GetClaimsPincipalAsync(this.AccessToken);//, authorizationServerId);
+            return await this.Client.GetClaimsPincipalAsync(this.AccessToken);
         }
 
         /// <inheritdoc/>
-        public async Task<RenewResponse> RenewAsync(bool refreshIdToken = false)//, string authorizationServerId = null)
+        public async Task<RenewResponse> RenewAsync(bool refreshIdToken = false)
         {
-			return await this.RenewAsync(this.RefreshToken, refreshIdToken);//, authorizationServerId);
+            return await this.RenewAsync(this.RefreshToken, refreshIdToken);
         }
 
         /// <inheritdoc/>
-        public async Task<RenewResponse> RenewAsync(string refreshToken, bool refreshIdToken = false)//, string authorizationServerId = null)
+        public async Task<RenewResponse> RenewAsync(string refreshToken, bool refreshIdToken = false)
         {
-			RenewResponse renewResponse = await this.Client.RenewAsync<RenewResponse>(refreshToken, refreshIdToken);//, authorizationServerId);
+            RenewResponse renewResponse = await this.Client.RenewAsync<RenewResponse>(refreshToken, refreshIdToken);
             this.RenewResponse = renewResponse;
             this.TokenType = renewResponse.TokenType;
             this.AccessToken = renewResponse.AccessToken;

--- a/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
@@ -321,44 +321,44 @@ namespace Okta.Xamarin
         }
 
         /// <inheritdoc/>
-        public async Task<T> GetUserAsync<T>(string authorizationServerId = null)
+        public async Task<T> GetUserAsync<T>()//string authorizationServerId = null)
         {
-            return await this.Client.GetUserAsync<T>(this.AccessToken, authorizationServerId);
+			return await this.Client.GetUserAsync<T>(this.AccessToken);//, authorizationServerId);
         }
 
         /// <inheritdoc/>
-        public async Task<Dictionary<string, object>> GetUserAsync(string authorizationServerId = null)
+        public async Task<Dictionary<string, object>> GetUserAsync()//string authorizationServerId = null)
         {
-            return await this.Client.GetUserAsync(this.AccessToken, authorizationServerId);
+			return await this.Client.GetUserAsync(this.AccessToken);//, authorizationServerId);
         }
 
         /// <inheritdoc/>
-        public async Task<Dictionary<string, object>> IntrospectAsync(TokenKind tokenKind, string authorizationServerId = null)
+        public async Task<Dictionary<string, object>> IntrospectAsync(TokenKind tokenKind)//, string authorizationServerId = null)
         {
             return await this.Client.IntrospectAsync(new IntrospectOptions
             {
                 Token = this.GetToken(tokenKind),
                 TokenKind = tokenKind,
-                AuthorizationServerId = authorizationServerId,
+                // AuthorizationServerId = authorizationServerId,
             });
         }
 
         /// <inheritdoc/>
-        public async Task<ClaimsPrincipal> GetClaimsPrincipalAsync(string authorizationServerId = null)
+        public async Task<ClaimsPrincipal> GetClaimsPrincipalAsync()//string authorizationServerId = null)
         {
-            return await this.Client.GetClaimsPincipalAsync(this.AccessToken, authorizationServerId);
+			return await this.Client.GetClaimsPincipalAsync(this.AccessToken);//, authorizationServerId);
         }
 
         /// <inheritdoc/>
-        public async Task<RenewResponse> RenewAsync(bool refreshIdToken = false, string authorizationServerId = null)
+        public async Task<RenewResponse> RenewAsync(bool refreshIdToken = false)//, string authorizationServerId = null)
         {
-            return await this.RenewAsync(this.RefreshToken, refreshIdToken, authorizationServerId);
+			return await this.RenewAsync(this.RefreshToken, refreshIdToken);//, authorizationServerId);
         }
 
         /// <inheritdoc/>
-        public async Task<RenewResponse> RenewAsync(string refreshToken, bool refreshIdToken = false, string authorizationServerId = null)
+        public async Task<RenewResponse> RenewAsync(string refreshToken, bool refreshIdToken = false)//, string authorizationServerId = null)
         {
-            RenewResponse renewResponse = await this.Client.RenewAsync<RenewResponse>(refreshToken, refreshIdToken, authorizationServerId);
+			RenewResponse renewResponse = await this.Client.RenewAsync<RenewResponse>(refreshToken, refreshIdToken);//, authorizationServerId);
             this.RenewResponse = renewResponse;
             this.TokenType = renewResponse.TokenType;
             this.AccessToken = renewResponse.AccessToken;

--- a/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
@@ -293,6 +293,7 @@ namespace Okta.Xamarin
             }
         }
 
+        /// <inheritdoc/>
         public virtual async Task RevokeAsync(TokenKind tokenKind, string token)
         {
             switch (tokenKind)
@@ -307,11 +308,13 @@ namespace Okta.Xamarin
             }
         }
 
+        /// <inheritdoc/>
         public async Task RevokeAccessTokenAsync(string token)
         {
             await this.Client.RevokeAccessTokenAsync(token);
         }
 
+        /// <inheritdoc/>
         public async Task RevokeRefreshTokenAsync(string token)
         {
             await this.Client.RevokeRefreshTokenAsync(token);

--- a/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
@@ -293,6 +293,30 @@ namespace Okta.Xamarin
             }
         }
 
+        public virtual async Task RevokeAsync(TokenKind tokenKind, string token)
+        {
+            switch (tokenKind)
+            {
+                case Xamarin.TokenKind.AccessToken:
+                    await this.Client.RevokeAccessTokenAsync(token);
+                    break;
+                case Xamarin.TokenKind.RefreshToken:
+                default:
+                    await this.Client.RevokeRefreshTokenAsync(token);
+                    break;
+            }
+        }
+
+        public async Task RevokeAccessTokenAsync(string token)
+        {
+            await this.Client.RevokeAccessTokenAsync(token);
+        }
+
+        public async Task RevokeRefreshTokenAsync(string token)
+        {
+            await this.Client.RevokeRefreshTokenAsync(token);
+        }
+
         /// <inheritdoc/>
         public async Task<T> GetUserAsync<T>(string authorizationServerId = null)
         {

--- a/Okta.Xamarin/Okta.Xamarin/RenewEventArgs.cs
+++ b/Okta.Xamarin/Okta.Xamarin/RenewEventArgs.cs
@@ -23,7 +23,7 @@ namespace Okta.Xamarin
         public string RefreshToken { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indication whether the id token is refreshed.
+        /// Gets or sets a value indicating whether the id token is refreshed.
         /// </summary>
         public bool RefreshIdToken { get; set; }
 

--- a/Okta.Xamarin/Okta.Xamarin/RenewExceptionEventArgs.cs
+++ b/Okta.Xamarin/Okta.Xamarin/RenewExceptionEventArgs.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Okta.Xamarin
+{
+    /// <summary>
+    /// Arguments relevant to renew exception events.
+    /// </summary>
+    public class RenewExceptionEventArgs : RenewEventArgs
+    {
+        /// <summary>
+        /// Gets or sets the exception that occurred.
+        /// </summary>
+        public Exception Exception { get; set; }
+    }
+}

--- a/Okta.Xamarin/Okta.Xamarin/RevokeExceptionEventArgs.cs
+++ b/Okta.Xamarin/Okta.Xamarin/RevokeExceptionEventArgs.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Okta.Xamarin
+{
+    /// <summary>
+    /// Arguments relevant to revoke exception events.
+    /// </summary>
+    public class RevokeExceptionEventArgs : RevokeEventArgs
+    {
+        /// <summary>
+        /// Gets or sets the exception that occurred.
+        /// </summary>
+        public Exception Exception { get; set; }
+    }
+}

--- a/Okta.Xamarin/Okta.Xamarin/ViewModels/RenewCommand.cs
+++ b/Okta.Xamarin/Okta.Xamarin/ViewModels/RenewCommand.cs
@@ -31,12 +31,12 @@ namespace Okta.Xamarin.ViewModels
         /// </summary>
         /// <param name="refreshIdToken">A value indicating whether to refresh the ID token.</param>
         /// <param name="authorizationServerId">The authorization server ID, the default is "default".</param>
-        public RenewCommand(bool refreshIdToken)//, string authorizationServerId = null)
+        public RenewCommand(bool refreshIdToken)
             : base(async () =>
             {
                 if (!string.IsNullOrEmpty(OktaContext.RefreshToken))
                 {
-					await OktaContext.RenewAsync(refreshIdToken);//, authorizationServerId);
+                    _ = await OktaContext.RenewAsync(refreshIdToken);
                 }
             })
         {

--- a/Okta.Xamarin/Okta.Xamarin/ViewModels/RenewCommand.cs
+++ b/Okta.Xamarin/Okta.Xamarin/ViewModels/RenewCommand.cs
@@ -31,12 +31,12 @@ namespace Okta.Xamarin.ViewModels
         /// </summary>
         /// <param name="refreshIdToken">A value indicating whether to refresh the ID token.</param>
         /// <param name="authorizationServerId">The authorization server ID, the default is "default".</param>
-        public RenewCommand(bool refreshIdToken, string authorizationServerId = null)
+        public RenewCommand(bool refreshIdToken)//, string authorizationServerId = null)
             : base(async () =>
             {
                 if (!string.IsNullOrEmpty(OktaContext.RefreshToken))
                 {
-                    await OktaContext.Current.RenewAsync(refreshIdToken, authorizationServerId);
+					await OktaContext.RenewAsync(refreshIdToken);//, authorizationServerId);
                 }
             })
         {

--- a/Okta.Xamarin/Okta.Xamarin/ViewModels/RenewCommand.cs
+++ b/Okta.Xamarin/Okta.Xamarin/ViewModels/RenewCommand.cs
@@ -31,7 +31,7 @@ namespace Okta.Xamarin.ViewModels
         /// </summary>
         /// <param name="refreshIdToken">A value indicating whether to refresh the ID token.</param>
         /// <param name="authorizationServerId">The authorization server ID, the default is "default".</param>
-        public RenewCommand(bool refreshIdToken, string authorizationServerId = "default")
+        public RenewCommand(bool refreshIdToken, string authorizationServerId = null)
             : base(async () =>
             {
                 if (!string.IsNullOrEmpty(OktaContext.RefreshToken))

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/HttpMessageHandlerMock.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/HttpMessageHandlerMock.cs
@@ -16,8 +16,12 @@ namespace Okta.Xamarin.Test
     {
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var content = await request.Content.ReadAsStringAsync();
-            System.Collections.Specialized.NameValueCollection data = System.Web.HttpUtility.ParseQueryString(content);
+            System.Collections.Specialized.NameValueCollection data = new System.Collections.Specialized.NameValueCollection();
+            if (request.Content != null)
+            {
+                string content = await request.Content.ReadAsStringAsync();
+                data = System.Web.HttpUtility.ParseQueryString(content);
+            }
             var response = Responder(
                 new Tuple<string, Dictionary<string, string>>(request.RequestUri.ToString(), data.ToDictionary()));
 

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClient.Test.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClient.Test.cs
@@ -109,6 +109,14 @@ namespace Okta.Xamarin
             this.OnRequestException(requestExceptionEventArgs);
         }
 
+        /// <summary>
+        /// Provides internal access to the call the PerformAuthorizationServerRequestAsync method.
+        /// </summary>
+        /// <param name="httpMethod">The http method.</param>
+        /// <param name="path">The path.</param>
+        /// <param name="headers">The headers.</param>
+        /// <param name="authorizationServerId">The authorization server id.</param>
+        /// <param name="formUrlEncodedContent">The content.</param>
         public void CallPerformAuthorizationServerRequestAsync(HttpMethod httpMethod, string path, Dictionary<string, string> headers, string authorizationServerId = null, params KeyValuePair<string, string>[] formUrlEncodedContent)
         {
             base.PerformAuthorizationServerRequestAsync(httpMethod, path, headers, authorizationServerId, formUrlEncodedContent);

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClient.Test.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClient.Test.cs
@@ -84,9 +84,9 @@ namespace Okta.Xamarin
         }
 
         /// <summary>
-        /// Allows setting a custom <see cref="HttpMessageHandler"/> for use by this client's <see cref="HttpClient"/>, in order to mock of HTTP requests
+        /// Allows setting a custom <see cref="HttpMessageHandler"/> for use by this client's <see cref="HttpClient"/>, in order to mock of HTTP requests.
         /// </summary>
-        /// <param name="handler"></param>
+        /// <param name="handler">The message handler.</param>
         public void SetMockHttpMessageHandler(HttpMessageHandler handler)
         {
             if (handler == null)
@@ -98,12 +98,16 @@ namespace Okta.Xamarin
         /// <summary>
         /// Provides internal access to the function which determines the AuthorizeUrl including login query parameters based on the <see cref="Config"/>
         /// </summary>
-        /// <returns>The url ready to be used for login</returns>
+        /// <returns>The url ready to be used for login.</returns>
         public string GenerateAuthorizeUrlTest()
         {
             return GenerateAuthorizeUrl();
         }
 
+        /// <summary>
+        /// Provided internal access to raise the RequestException event.
+        /// </summary>
+        /// <param name="requestExceptionEventArgs">The event arguments.</param>
         public void RaiseRequestExceptionEvent(RequestExceptionEventArgs requestExceptionEventArgs)
         {
             this.OnRequestException(requestExceptionEventArgs);
@@ -115,11 +119,10 @@ namespace Okta.Xamarin
         /// <param name="httpMethod">The http method.</param>
         /// <param name="path">The path.</param>
         /// <param name="headers">The headers.</param>
-        /// <param name="authorizationServerId">The authorization server id.</param>
         /// <param name="formUrlEncodedContent">The content.</param>
-        public void CallPerformAuthorizationServerRequestAsync(HttpMethod httpMethod, string path, Dictionary<string, string> headers, /* string authorizationServerId = null,*/ params KeyValuePair<string, string>[] formUrlEncodedContent)
+        public void CallPerformAuthorizationServerRequestAsync(HttpMethod httpMethod, string path, Dictionary<string, string> headers, params KeyValuePair<string, string>[] formUrlEncodedContent)
         {
-            base.PerformAuthorizationServerRequestAsync(httpMethod, path, headers, /*authorizationServerId, */ formUrlEncodedContent);
+            base.PerformAuthorizationServerRequestAsync(httpMethod, path, headers, formUrlEncodedContent);
         }
     }
 }

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClient.Test.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClient.Test.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -86,7 +87,7 @@ namespace Okta.Xamarin
         /// Allows setting a custom <see cref="HttpMessageHandler"/> for use by this client's <see cref="HttpClient"/>, in order to mock of HTTP requests
         /// </summary>
         /// <param name="handler"></param>
-        public void SetHttpMock(HttpMessageHandler handler)
+        public void SetMockHttpMessageHandler(HttpMessageHandler handler)
         {
             if (handler == null)
                 client = new HttpClient();
@@ -106,6 +107,11 @@ namespace Okta.Xamarin
         public void RaiseRequestExceptionEvent(RequestExceptionEventArgs requestExceptionEventArgs)
         {
             this.OnRequestException(requestExceptionEventArgs);
+        }
+
+        public void CallPerformAuthorizationServerRequestAsync(HttpMethod httpMethod, string path, Dictionary<string, string> headers, string authorizationServerId = null, params KeyValuePair<string, string>[] formUrlEncodedContent)
+        {
+            base.PerformAuthorizationServerRequestAsync(httpMethod, path, headers, authorizationServerId, formUrlEncodedContent);
         }
     }
 }

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClient.Test.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClient.Test.cs
@@ -117,9 +117,9 @@ namespace Okta.Xamarin
         /// <param name="headers">The headers.</param>
         /// <param name="authorizationServerId">The authorization server id.</param>
         /// <param name="formUrlEncodedContent">The content.</param>
-        public void CallPerformAuthorizationServerRequestAsync(HttpMethod httpMethod, string path, Dictionary<string, string> headers, string authorizationServerId = null, params KeyValuePair<string, string>[] formUrlEncodedContent)
+        public void CallPerformAuthorizationServerRequestAsync(HttpMethod httpMethod, string path, Dictionary<string, string> headers, /* string authorizationServerId = null,*/ params KeyValuePair<string, string>[] formUrlEncodedContent)
         {
-            base.PerformAuthorizationServerRequestAsync(httpMethod, path, headers, authorizationServerId, formUrlEncodedContent);
+            base.PerformAuthorizationServerRequestAsync(httpMethod, path, headers, /*authorizationServerId, */ formUrlEncodedContent);
         }
     }
 }

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClientShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClientShould.cs
@@ -3,14 +3,16 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using NSubstitute;
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace Okta.Xamarin.Test
 {
-	public class OidcClientShould
+    public class OidcClientShould
     {
         [Fact]
         public void FailWithInvalidConfig()
@@ -21,7 +23,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public void GetCorrectAuthUrl()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect+&TEST!@url%20Encode#*^(0)", "com.test:/logout") { Scope = "test hello test_scope" });
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect+&TEST!@url%20Encode#*^(0)", "com.test:/logout") { Scope = "test hello test_scope" });
 
             string url = client.GenerateAuthorizeUrlTest();
             Assert.StartsWith("https://dev-00000.oktapreview.com/oauth2/default/v1/authorize?", url);
@@ -33,7 +35,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public async void LaunchBrowserCorrectly()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             bool didLaunchBrowser = false;
 
@@ -51,7 +53,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public async void CloseBrowserCorrectly()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             bool didCloseBrowser = false;
 
@@ -73,7 +75,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public async void RequestAccessToken()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             bool didRequestAccessToken = false;
 
@@ -93,7 +95,7 @@ namespace Okta.Xamarin.Test
                     @"{ ""access_token"": ""access_token_example"", ""token_type"": ""testing""}");
             };
 
-            client.SetHttpMock(mockHttpClient);
+            client.SetMockHttpMessageHandler(mockHttpClient);
 
             client.OnLaunchBrowser = new Action<string>(url =>
             {
@@ -109,7 +111,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public void SuccessfullyGetAccessToken()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             HttpMessageHandlerMock mockHttpClient = new HttpMessageHandlerMock();
             mockHttpClient.Responder = (request) =>
@@ -122,7 +124,7 @@ namespace Okta.Xamarin.Test
                     @"{ ""access_token"": ""access_token_example"", ""token_type"": ""testing""}");
             };
 
-            client.SetHttpMock(mockHttpClient);
+            client.SetMockHttpMessageHandler(mockHttpClient);
 
             client.OnLaunchBrowser = new Action<string>(url =>
                 OidcClient.CaptureRedirectUrl(new Uri(client.Config.RedirectUri + "?code=12345&state=" + client.State_Internal)));
@@ -153,7 +155,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public async void FailOnStateMismatchInInitialRequest()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             client.OnLaunchBrowser = new Action<string>(url =>
             {
@@ -167,7 +169,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public async void FailOnErrorInInitialRequest()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             client.OnLaunchBrowser = new Action<string>(url =>
             {
@@ -181,7 +183,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public async void RaiseAuthenticationFailedEvent()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             client.OnLaunchBrowser = new Action<string>(url =>
             {
@@ -207,7 +209,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public async void FailOnErrorDataInAccessTokenRequest()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             HttpMessageHandlerMock mockHttpClient = new HttpMessageHandlerMock();
             mockHttpClient.Responder = (request) =>
@@ -220,7 +222,7 @@ namespace Okta.Xamarin.Test
                     @"{ ""error"": ""test_failure"", ""token_type"": ""testing""}");
             };
 
-            client.SetHttpMock(mockHttpClient);
+            client.SetMockHttpMessageHandler(mockHttpClient);
 
             client.OnLaunchBrowser = new Action<string>(url =>
             {
@@ -233,7 +235,7 @@ namespace Okta.Xamarin.Test
         [Fact]
         public async void FailGracefullyOnHttpErrorInAccessTokenRequest()
         {
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
 
             HttpMessageHandlerMock mockHttpClient = new HttpMessageHandlerMock();
             mockHttpClient.Responder = (request) =>
@@ -246,7 +248,7 @@ namespace Okta.Xamarin.Test
                     @"{ ""error"": ""not_authorized"", ""token_type"": ""testing""}");
             };
 
-            client.SetHttpMock(mockHttpClient);
+            client.SetMockHttpMessageHandler(mockHttpClient);
 
             client.OnLaunchBrowser = new Action<string>(url =>
             {
@@ -275,7 +277,7 @@ namespace Okta.Xamarin.Test
         public async void LaunchBrowserIfAuthenticatedOnSignOut()
         {
             bool? browserLaunched = false;
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
             client.OnLaunchBrowser = (url) => browserLaunched = true;
             client.SignOutOfOktaAsync(new OktaStateManager("testAccessToken", "testTokenType"));
             Assert.True(browserLaunched);
@@ -285,10 +287,200 @@ namespace Okta.Xamarin.Test
         public void NotLaunchBrowserIfNotAuthenticatedOnSignOut()
         {
             bool? browserLaunched = false;
-			TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
+            TestOidcClient client = new TestOidcClient(new OktaConfig("testoktaid", "https://dev-00000.oktapreview.com", "com.test:/redirect", "com.test:/logout"));
             client.OnLaunchBrowser = (url) => browserLaunched = true;
             client.SignOutOfOktaAsync(new OktaStateManager(string.Empty, string.Empty));
             Assert.False(browserLaunched);
+        }
+
+        [Fact]
+        public void UseAuthorizationServerIdFromConfig()
+        {
+            string testClientId = "test client id";
+            string testAuthorizationServerId = "test authorization server id";
+            OktaConfig testConfig = new OktaConfig
+            {
+                OktaDomain = "https://fake.cxm/",
+                RedirectUri = "https://fake.cxm/redirect",
+                PostLogoutRedirectUri = "https://fake.cxm/logoutRedirect",
+                ClientId = testClientId,
+                AuthorizationServerId = testAuthorizationServerId,
+            };
+            bool? requestReceived = false;
+            string testResponse = "test response";
+            HttpMessageHandlerMock mockHttpMessageHandler = new HttpMessageHandlerMock();
+            mockHttpMessageHandler.Responder = (request) =>
+            {
+                string url = request.Item1;
+                Dictionary<string, string> data = request.Item2;
+
+                Assert.Equal($"https://fake.cxm/oauth2/{testAuthorizationServerId}/v1/testPath", url);
+
+                requestReceived = true;
+
+                return new Tuple<System.Net.HttpStatusCode, string>(
+                    System.Net.HttpStatusCode.OK, testResponse);
+            };
+            TestOidcClient testOidcClient = new TestOidcClient(testConfig);
+            testOidcClient.SetMockHttpMessageHandler(mockHttpMessageHandler);
+
+            testOidcClient.CallPerformAuthorizationServerRequestAsync(HttpMethod.Post, "/testPath", new Dictionary<string, string>());
+
+            Assert.True(requestReceived);
+        }
+
+        [Fact]
+        public void UseAuthorizationServerIdFromConfigOnRevokeAccessToken()
+        {
+            string testClientId = "test client id";
+            string testAccessToken = "test access token";
+            string testAuthorizationServerId = "test authorization server id";
+            OktaConfig testConfig = new OktaConfig
+            {
+                OktaDomain = "https://fake.cxm/",
+                RedirectUri = "https://fake.cxm/redirect",
+                PostLogoutRedirectUri = "https://fake.cxm/logoutRedirect",
+                ClientId = testClientId,
+                AuthorizationServerId = testAuthorizationServerId,
+            };
+            bool? requestReceived = false;
+            string testResponse = "test response";
+            HttpMessageHandlerMock mockHttpMessageHandler = new HttpMessageHandlerMock();
+            mockHttpMessageHandler.Responder = (request) =>
+            {
+                string url = request.Item1;
+                Dictionary<string, string> data = request.Item2;
+
+                Assert.Equal($"https://fake.cxm/oauth2/{testAuthorizationServerId}/v1/revoke", url);
+                Assert.Equal(testAccessToken, data["token"]);
+                Assert.Equal("access_token", data["token_type_hint"]);
+                Assert.Equal(testClientId, data["client_id"]);
+                requestReceived = true;
+
+                return new Tuple<System.Net.HttpStatusCode, string>(
+                    System.Net.HttpStatusCode.OK, testResponse);
+            };
+            TestOidcClient testOidcClient = new TestOidcClient(testConfig);
+            testOidcClient.SetMockHttpMessageHandler(mockHttpMessageHandler);
+
+            testOidcClient.RevokeAccessTokenAsync(testAccessToken).Wait();
+
+            Assert.True(requestReceived);
+        }
+
+        [Fact]
+        public void UseAuthorizationServerIdFromConfigOnRevokeRefreshToken()
+        {
+            string testClientId = "test client id";
+            string testRefreshToken = "test refresh token";
+            string testAuthorizationServerId = "test authorization server id";
+            OktaConfig testConfig = new OktaConfig
+            {
+                OktaDomain = "https://fake.cxm/",
+                RedirectUri = "https://fake.cxm/redirect",
+                PostLogoutRedirectUri = "https://fake.cxm/logoutRedirect",
+                ClientId = testClientId,
+                AuthorizationServerId = testAuthorizationServerId,
+            };
+            bool? requestReceived = false;
+            string testResponse = "test response";
+            HttpMessageHandlerMock mockHttpMessageHandler = new HttpMessageHandlerMock();
+            mockHttpMessageHandler.Responder = (request) =>
+            {
+                string url = request.Item1;
+                Dictionary<string, string> data = request.Item2;
+
+                Assert.Equal($"https://fake.cxm/oauth2/{testAuthorizationServerId}/v1/revoke", url);
+                Assert.Equal(testRefreshToken, data["token"]);
+                Assert.Equal("refresh_token", data["token_type_hint"]);
+                Assert.Equal(testClientId, data["client_id"]);
+                requestReceived = true;
+
+                return new Tuple<System.Net.HttpStatusCode, string>(
+                    System.Net.HttpStatusCode.OK, testResponse);
+            };
+            TestOidcClient testOidcClient = new TestOidcClient(testConfig);
+            testOidcClient.SetMockHttpMessageHandler(mockHttpMessageHandler);
+
+            testOidcClient.RevokeRefreshTokenAsync(testRefreshToken).Wait();
+
+            Assert.True(requestReceived);
+        }
+
+        [Fact]
+        public void UseDefaultAuthorizationServerIfNullInConfigOnRevokeAccessToken()
+        {
+            string testAccessToken = "test access token";
+            string testClientId = "test client id";
+            OktaConfig testConfig = new OktaConfig
+            {
+                OktaDomain = "https://fake.cxm/",
+                RedirectUri = "https://fake.cxm/redirect",
+                PostLogoutRedirectUri = "https://fake.cxm/logoutRedirect",
+                ClientId = testClientId,
+                AuthorizationServerId = null,
+            };
+            bool? requestReceived = false;
+            string testResponse = "test response";
+            HttpMessageHandlerMock mockHttpMessageHandler = new HttpMessageHandlerMock();
+            mockHttpMessageHandler.Responder = (request) =>
+            {
+                string url = request.Item1;
+                Dictionary<string, string> data = request.Item2;
+
+                Assert.Equal($"https://fake.cxm/oauth2/default/v1/revoke", url);
+                Assert.Equal(testAccessToken, data["token"]);
+                Assert.Equal("access_token", data["token_type_hint"]);
+                Assert.Equal(testClientId, data["client_id"]);
+                requestReceived = true;
+
+                return new Tuple<System.Net.HttpStatusCode, string>(
+                    System.Net.HttpStatusCode.OK, testResponse);
+            };
+            TestOidcClient testOidcClient = new TestOidcClient(testConfig);
+            testOidcClient.SetMockHttpMessageHandler(mockHttpMessageHandler);
+
+            testOidcClient.RevokeAccessTokenAsync(testAccessToken).Wait();
+
+            Assert.True(requestReceived);
+        }
+
+        [Fact]
+        public void UseDefaultAuthorizationServerIfNullInConfigOnRevokeRefreshToken()
+        {
+            string testRefreshToken = "test access token";
+            string testClientId = "test client id";
+            OktaConfig testConfig = new OktaConfig
+            {
+                OktaDomain = "https://fake.cxm/",
+                RedirectUri = "https://fake.cxm/redirect",
+                PostLogoutRedirectUri = "https://fake.cxm/logoutRedirect",
+                ClientId = testClientId,
+                AuthorizationServerId = null,
+            };
+            bool? requestReceived = false;
+            string testResponse = "test response";
+            HttpMessageHandlerMock mockHttpMessageHandler = new HttpMessageHandlerMock();
+            mockHttpMessageHandler.Responder = (request) =>
+            {
+                string url = request.Item1;
+                Dictionary<string, string> data = request.Item2;
+
+                Assert.Equal($"https://fake.cxm/oauth2/default/v1/revoke", url);
+                Assert.Equal(testRefreshToken, data["token"]);
+                Assert.Equal("refresh_token", data["token_type_hint"]);
+                Assert.Equal(testClientId, data["client_id"]);
+                requestReceived = true;
+
+                return new Tuple<System.Net.HttpStatusCode, string>(
+                    System.Net.HttpStatusCode.OK, testResponse);
+            };
+            TestOidcClient testOidcClient = new TestOidcClient(testConfig);
+            testOidcClient.SetMockHttpMessageHandler(mockHttpMessageHandler);
+
+            testOidcClient.RevokeRefreshTokenAsync(testRefreshToken).Wait();
+
+            Assert.True(requestReceived);
         }
     }
 }

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaContextShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaContextShould.cs
@@ -451,5 +451,20 @@ namespace Okta.Xamarin.Test
 
             revokeExceptionEventRaised.Should().BeTrue();
         }
+
+        [Fact]
+        public void RevokeSpecifiedAccessToken()
+        {
+            string goodAccessToken = "this is the one";
+            string badAccessToken = "this is the wrong one";
+            IOktaStateManager mockOktaStateManager = Substitute.For<IOktaStateManager>();
+            mockOktaStateManager.AccessToken.Returns(badAccessToken);
+
+            OktaContext oktaContext = new OktaContext() { StateManager = mockOktaStateManager };
+            OktaContext.Current = oktaContext;
+            OktaContext.RevokeAccessTokenAsync(goodAccessToken).Wait();
+
+            mockOktaStateManager.Received().RevokeAccessTokenAsync(goodAccessToken);
+        }
     }
 }

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaContextShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaContextShould.cs
@@ -345,6 +345,7 @@ namespace Okta.Xamarin.Test
         public void RaiseRenewEvents()
         {
             IOktaStateManager testStateManager = Substitute.For<IOktaStateManager>();
+            testStateManager.RefreshToken.Returns("test refresh token");
             Task<RenewResponse> testRenewResponse = Task.FromResult(new RenewResponse());
             testStateManager.RenewAsync().Returns(testRenewResponse);
             OktaContext.Current.StateManager = testStateManager;
@@ -415,9 +416,12 @@ namespace Okta.Xamarin.Test
         {
             bool? renewExceptionEventRaised = false;
             Exception testException = new Exception("This is a test exception");
+            IOktaStateManager mockStateManager = Substitute.For<IOktaStateManager>();
+            mockStateManager.RefreshToken.Returns("test refresh token");
             IOidcClient mockClient = Substitute.For<IOidcClient>();
             mockClient.RenewAsync<RenewResponse>(Arg.Any<string>()).Returns(new RenewResponse());
-            OktaContext.Current.StateManager.Client = mockClient;
+            mockStateManager.Client.Returns(mockClient);
+            OktaContext.Current.StateManager = mockStateManager;
             OktaContext.AddRenewExceptionListener((sender, renewExceptionEventArgs) =>
             {
                 renewExceptionEventArgs.Exception.Should().Be(testException);

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaStateManagerShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaStateManagerShould.cs
@@ -119,5 +119,32 @@ namespace Okta.Xamarin.Test
             result.IdToken.Should().BeEquivalentTo(testIdToken);
             result.Scope.Should().BeEquivalentTo(testScope);
         }
+
+        // OKTA-417977
+        [Fact]
+        public void CallClientRevokeAccessToken()
+        {
+            string testAccessToken = "test access token";
+            IOidcClient mockClient = Substitute.For<IOidcClient>();
+            OktaStateManager oktaStateManager = new OktaStateManager { Client = mockClient, AccessToken = testAccessToken };
+
+            oktaStateManager.RevokeAsync(TokenKind.AccessToken).Wait();
+
+            mockClient.Received().RevokeAccessTokenAsync(testAccessToken);
+        }
+
+        [Fact]
+        public void CallClientRevokeRefreshToken()
+        {
+            string testRefreshToken = "test refresh token";
+            IOidcClient mockClient = Substitute.For<IOidcClient>();
+            OktaStateManager oktaStateManager = new OktaStateManager { Client = mockClient, RefreshToken = testRefreshToken };
+
+            oktaStateManager.RevokeAsync(TokenKind.RefreshToken).Wait();
+
+            mockClient.Received().RevokeRefreshTokenAsync(testRefreshToken);
+        }
+
+        // - OKTA-417977
     }
 }

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaStateManagerShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaStateManagerShould.cs
@@ -144,7 +144,6 @@ namespace Okta.Xamarin.Test
 
             mockClient.Received().RevokeRefreshTokenAsync(testRefreshToken);
         }
-
         // - OKTA-417977
     }
 }

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaStateManagerShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaStateManagerShould.cs
@@ -120,7 +120,6 @@ namespace Okta.Xamarin.Test
             result.Scope.Should().BeEquivalentTo(testScope);
         }
 
-        // OKTA-417977
         [Fact]
         public void CallClientRevokeAccessToken()
         {
@@ -144,6 +143,5 @@ namespace Okta.Xamarin.Test
 
             mockClient.Received().RevokeRefreshTokenAsync(testRefreshToken);
         }
-        // - OKTA-417977
     }
 }

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/TestOktaStateManager.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/TestOktaStateManager.cs
@@ -3,6 +3,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using NSubstitute;
 using System;
 using System.Threading.Tasks;
 
@@ -15,6 +16,7 @@ namespace Okta.Xamarin.Test
         public TestOktaStateManager(string accessToken, string idToken = null, string refreshToken = null, int? expiresIn = null, string scope = null)
         : base(accessToken, null, idToken, refreshToken, expiresIn, scope) 
         {
+			this.Client = Substitute.For<IOidcClient>();
         }
 
         public TestOktaStateManager(string accessToken, string refreshToken) : this(accessToken, null, refreshToken) { }

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/TestOktaStateManager.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/TestOktaStateManager.cs
@@ -3,9 +3,8 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
-using NSubstitute;
-using System;
 using System.Threading.Tasks;
+using NSubstitute;
 
 namespace Okta.Xamarin.Test
 {
@@ -16,7 +15,7 @@ namespace Okta.Xamarin.Test
         public TestOktaStateManager(string accessToken, string idToken = null, string refreshToken = null, int? expiresIn = null, string scope = null)
         : base(accessToken, null, idToken, refreshToken, expiresIn, scope) 
         {
-			this.Client = Substitute.For<IOidcClient>();
+            this.Client = Substitute.For<IOidcClient>();
         }
 
         public TestOktaStateManager(string accessToken, string refreshToken) : this(accessToken, null, refreshToken) { }


### PR DESCRIPTION
- [x] Change the signature of `OidcClient.PerformAuthorizationServerRequestAsync` so that the default value of the authorizationServerId is null
- [x] If the authorizationServerId argument is null use the value from configuration
- [x] Remove `authorizationServerId` parameter from all methods that declare a parameter `authorizationServerId = “default”` 
- [x] Add RevokeException event
- [x] Add RenewException event
- [x] Add convenience method `OktaContext.RevokeAccessToken(string accessToken)`
- [x] Add convenience method `OktaContext.RevokeRefreshToken(string refreshToken)`
- [x] Add unit tests for new methods and events

When complete, this resolves #58 