### PR TITLE
OKTA-428722: add auth code exchange failed event

### DIFF
--- a/Okta.Xamarin/Okta.Xamarin/AuthCodeTokenExchangeExceptionEventArgs.cs
+++ b/Okta.Xamarin/Okta.Xamarin/AuthCodeTokenExchangeExceptionEventArgs.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace Okta.Xamarin
 {
     /// <summary>
-    /// Data relevant to AuthCodeTokenExchangeFailed events.
+    /// Data relevant to AuthCodeTokenExchangeException events.
     /// </summary>
     public class AuthCodeTokenExchangeExceptionEventArgs : EventArgs
     {

--- a/Okta.Xamarin/Okta.Xamarin/AuthCodeTokenExchangeExceptionEventArgs.cs
+++ b/Okta.Xamarin/Okta.Xamarin/AuthCodeTokenExchangeExceptionEventArgs.cs
@@ -7,7 +7,7 @@ namespace Okta.Xamarin
     /// <summary>
     /// Data relevant to AuthCodeTokenExchangeFailed events.
     /// </summary>
-    public class AuthCodeTokenExchangeFailedEventArgs : EventArgs
+    public class AuthCodeTokenExchangeExceptionEventArgs : EventArgs
     {
         /// <summary>
         /// Gets or sets the OidcClient.

--- a/Okta.Xamarin/Okta.Xamarin/AuthCodeTokenExchangeExceptionEventArgs.cs
+++ b/Okta.Xamarin/Okta.Xamarin/AuthCodeTokenExchangeExceptionEventArgs.cs
@@ -1,6 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// <copyright file="AuthCodeTokenExchangeExceptionEventArgs.cs" company="Okta, Inc">
+// Copyright (c) 2020 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
 
 namespace Okta.Xamarin
 {

--- a/Okta.Xamarin/Okta.Xamarin/AuthCodeTokenExchangeFailedEventArgs.cs
+++ b/Okta.Xamarin/Okta.Xamarin/AuthCodeTokenExchangeFailedEventArgs.cs
@@ -4,9 +4,19 @@ using System.Text;
 
 namespace Okta.Xamarin
 {
-	public class AuthCodeTokenExchangeFailedEventArgs : EventArgs
-	{
-		public IOidcClient OidcClient { get; set; }
-		public Exception Exception { get; set; }
-	}
+    /// <summary>
+    /// Data relevant to AuthCodeTokenExchangeFailed events.
+    /// </summary>
+    public class AuthCodeTokenExchangeFailedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets or sets the OidcClient.
+        /// </summary>
+        public IOidcClient OidcClient { get; set; }
+
+        /// <summary>
+        /// Gets or sets the exception.
+        /// </summary>
+        public Exception Exception { get; set; }
+    }
 }

--- a/Okta.Xamarin/Okta.Xamarin/AuthCodeTokenExchangeFailedEventArgs.cs
+++ b/Okta.Xamarin/Okta.Xamarin/AuthCodeTokenExchangeFailedEventArgs.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Okta.Xamarin
+{
+	public class AuthCodeTokenExchangeFailedEventArgs : EventArgs
+	{
+		public IOidcClient OidcClient { get; set; }
+		public Exception Exception { get; set; }
+	}
+}

--- a/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
@@ -31,7 +31,7 @@ namespace Okta.Xamarin
         /// <summary>
         /// The event that is raised when the exchange of code for tokens throws an exception.
         /// </summary>
-        public event EventHandler<AuthCodeTokenExchangeExceptionEventArgs> AuthCodeTokenExchangeException;
+        public event EventHandler<AuthCodeTokenExchangeExceptionEventArgs> AuthCodeTokenExchangeExceptionThrown;
 
         /// <summary>
         /// Gets or sets the OAuthException that occurred if any.  Is null if no exception occurred.
@@ -531,7 +531,7 @@ namespace Okta.Xamarin
             }
             catch (Exception ex)
             {
-                this.OnAuthCodeTokenExchangeException(new AuthCodeTokenExchangeExceptionEventArgs { OidcClient = this, Exception = ex });
+                this.OnAuthCodeTokenExchangeExceptionThrown(new AuthCodeTokenExchangeExceptionEventArgs { OidcClient = this, Exception = ex });
                 this.currentTask?.SetException(ex);
             }
         }
@@ -540,9 +540,9 @@ namespace Okta.Xamarin
         /// Invokes the `AuthCodeTokenExchangeException` event.
         /// </summary>
         /// <param name="args">The event arguments.</param>
-        protected void OnAuthCodeTokenExchangeException(AuthCodeTokenExchangeExceptionEventArgs args)
+        protected void OnAuthCodeTokenExchangeExceptionThrown(AuthCodeTokenExchangeExceptionEventArgs args)
         {
-            this.AuthCodeTokenExchangeException?.Invoke(this, args);
+            this.AuthCodeTokenExchangeExceptionThrown?.Invoke(this, args);
         }
 
         /// <summary>

--- a/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
@@ -536,6 +536,10 @@ namespace Okta.Xamarin
             }
         }
 
+        /// <summary>
+        /// Invokes the `AuthCodeTokenExchangeException` event.
+        /// </summary>
+        /// <param name="args">The event arguments.</param>
         protected void OnAuthCodeTokenExchangeException(AuthCodeTokenExchangeExceptionEventArgs args)
         {
             this.AuthCodeTokenExchangeException?.Invoke(this, args);

--- a/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
@@ -29,9 +29,9 @@ namespace Okta.Xamarin
         public event EventHandler<RequestExceptionEventArgs> RequestException;
 
         /// <summary>
-        /// The event that is raised when the exchange of code for tokens fails.
+        /// The event that is raised when the exchange of code for tokens throws an exception.
         /// </summary>
-        public event EventHandler<AuthCodeTokenExchangeFailedEventArgs> AuthCodeTokenExchangeFailed;
+        public event EventHandler<AuthCodeTokenExchangeExceptionEventArgs> AuthCodeTokenExchangeException;
 
         /// <summary>
         /// Gets or sets the OAuthException that occurred if any.  Is null if no exception occurred.
@@ -531,14 +531,14 @@ namespace Okta.Xamarin
             }
             catch (Exception ex)
             {
-                this.OnAuthCodeTokenExchangeFailed(new AuthCodeTokenExchangeFailedEventArgs { OidcClient = this, Exception = ex });
-                this.currentTask.SetException(ex);
+                this.OnAuthCodeTokenExchangeException(new AuthCodeTokenExchangeExceptionEventArgs { OidcClient = this, Exception = ex });
+                this.currentTask?.SetException(ex);
             }
         }
 
-        protected void OnAuthCodeTokenExchangeFailed(AuthCodeTokenExchangeFailedEventArgs args)
+        protected void OnAuthCodeTokenExchangeException(AuthCodeTokenExchangeExceptionEventArgs args)
         {
-            this.AuthCodeTokenExchangeFailed?.Invoke(this, args);
+            this.AuthCodeTokenExchangeException?.Invoke(this, args);
         }
 
         /// <summary>

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClient.Test.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClient.Test.cs
@@ -124,5 +124,10 @@ namespace Okta.Xamarin
         {
             base.PerformAuthorizationServerRequestAsync(httpMethod, path, headers, formUrlEncodedContent);
         }
+
+        public async Task CallExchangeCodeForTokenAsync(string code)
+        {
+            await ExchangeAuthCodeForTokenAsync(code);
+        }
     }
 }

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClientShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClientShould.cs
@@ -483,7 +483,7 @@ namespace Okta.Xamarin.Test
         }
 
         [Fact]
-        public void RaiseAuthCodeTokenExchangeFailedEvent()
+        public void RaiseAuthCodeTokenExchangeExceptionEvent()
         {
             string testClientId = "test client id";
             OktaConfig testConfig = new OktaConfig

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClientShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClientShould.cs
@@ -506,7 +506,7 @@ namespace Okta.Xamarin.Test
             testOidcClient.SetMockHttpMessageHandler(mockHttpMessageHandler);
 
             bool? eventWasRaised = false;
-            testOidcClient.AuthCodeTokenExchangeFailed += (sender, args) =>
+            testOidcClient.AuthCodeTokenExchangeException += (sender, args) =>
             {
                 eventWasRaised = true;
             };

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClientShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClientShould.cs
@@ -483,7 +483,7 @@ namespace Okta.Xamarin.Test
         }
 
         [Fact]
-        public void RaiseAuthCodeTokenExchangeExceptionEvent()
+        public void RaiseAuthCodeTokenExchangeExceptionThrownEvent()
         {
             string testClientId = "test client id";
             OktaConfig testConfig = new OktaConfig
@@ -506,7 +506,7 @@ namespace Okta.Xamarin.Test
             testOidcClient.SetMockHttpMessageHandler(mockHttpMessageHandler);
 
             bool? eventWasRaised = false;
-            testOidcClient.AuthCodeTokenExchangeException += (sender, args) =>
+            testOidcClient.AuthCodeTokenExchangeExceptionThrown += (sender, args) =>
             {
                 eventWasRaised = true;
             };

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClientShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClientShould.cs
@@ -3,7 +3,6 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
-using NSubstitute;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
@@ -265,9 +264,9 @@ namespace Okta.Xamarin.Test
             Assert.True(string.IsNullOrEmpty(client.State_Internal));
             Assert.True(string.IsNullOrEmpty(client.CodeChallenge_Internal));
             Assert.True(string.IsNullOrEmpty(client.CodeVerifier_Internal));
-            
+
             client.SignOutOfOktaAsync(new OktaStateManager("testAccessToken", "testTokenType"));
-            
+
             Assert.False(string.IsNullOrEmpty(client.State_Internal));
             Assert.False(string.IsNullOrEmpty(client.CodeChallenge_Internal));
             Assert.False(string.IsNullOrEmpty(client.CodeVerifier_Internal));
@@ -282,7 +281,7 @@ namespace Okta.Xamarin.Test
             client.SignOutOfOktaAsync(new OktaStateManager("testAccessToken", "testTokenType"));
             Assert.True(browserLaunched);
         }
-        
+
         [Fact]
         public void NotLaunchBrowserIfNotAuthenticatedOnSignOut()
         {
@@ -481,6 +480,40 @@ namespace Okta.Xamarin.Test
             testOidcClient.RevokeRefreshTokenAsync(testRefreshToken).Wait();
 
             Assert.True(requestReceived);
+        }
+
+        [Fact]
+        public void RaiseAuthCodeTokenExchangeFailedEvent()
+        {
+            string testClientId = "test client id";
+            OktaConfig testConfig = new OktaConfig
+            {
+                OktaDomain = "https://fake.cxm/",
+                RedirectUri = "https://fake.cxm/redirect",
+                PostLogoutRedirectUri = "https://fake.cxm/logoutRedirect",
+                ClientId = testClientId,
+                AuthorizationServerId = null,
+            };
+
+            bool? requestReceived = false;
+            HttpMessageHandlerMock mockHttpMessageHandler = new HttpMessageHandlerMock();
+            mockHttpMessageHandler.GetTestResponse = (request, cancellationToken) =>
+            {
+                requestReceived = true;
+                throw new Exception("test exception to simulate request failure");
+            };
+            TestOidcClient testOidcClient = new TestOidcClient(testConfig);
+            testOidcClient.SetMockHttpMessageHandler(mockHttpMessageHandler);
+
+            bool? eventWasRaised = false;
+            testOidcClient.AuthCodeTokenExchangeFailed += (sender, args) =>
+            {
+                eventWasRaised = true;
+            };
+
+            testOidcClient.CallExchangeCodeForTokenAsync("test code").Wait();
+            Assert.True(requestReceived);
+            Assert.True(eventWasRaised);
         }
     }
 }


### PR DESCRIPTION
- Added OidcClient.AuthCodeTokenExchangeFailed event
- Wrapped body of ExchangeAuthCodeForTokenAsync in try/catch (the diff is hard to read)
- Added unit test

Fixes #65 
Fixes #44 