### PR TITLE
Fix flaky tests

### DIFF
--- a/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
@@ -131,7 +131,7 @@ namespace Okta.Xamarin
         {
             validator.Validate(this.Config);
             this.currentTask = new TaskCompletionSource<IOktaStateManager>();
-            if (stateManager == null || stateManager.IsAuthenticated == false)
+            if (stateManager == null || stateManager?.IsAuthenticated == false)
             {
                 this.currentTask.SetResult(stateManager ?? new OktaStateManager());
                 return this.currentTask.Task;

--- a/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
@@ -19,7 +19,7 @@ namespace Okta.Xamarin
     {
         private static Lazy<OktaContext> current = new Lazy<OktaContext>(() => new OktaContext());
         private static Lazy<TinyIoCContainer> container = new Lazy<TinyIoCContainer>(() => new TinyIoCContainer());
-        private IOktaStateManager stateManager;
+        private Lazy<IOktaStateManager> stateManager = new Lazy<IOktaStateManager>(() => new OktaStateManager());
         private OAuthException oAuthException;
 
         /// <summary>
@@ -27,7 +27,6 @@ namespace Okta.Xamarin
         /// </summary>
         public OktaContext()
         {
-            this.stateManager = new OktaStateManager();
         }
 
         /// <summary>
@@ -257,19 +256,19 @@ namespace Okta.Xamarin
         /// </summary>
         public IOktaStateManager StateManager
         {
-            get => this.stateManager;
+            get => this.stateManager.Value;
             set
             {
-                this.stateManager = value;
-                if (this.stateManager != null)
+                this.stateManager = new Lazy<IOktaStateManager>(() => value);
+                if (this.stateManager.Value != null)
                 {
-                    this.stateManager.RequestException += this.OnRequestException;
-                    this.stateManager.SecureStorageReadStarted += this.OnSecureStorageReadStarted;
-                    this.stateManager.SecureStorageReadCompleted += this.OnSecureStorageReadCompleted;
-                    this.stateManager.SecureStorageReadException += this.OnSecureStorageReadException;
-                    this.stateManager.SecureStorageWriteStarted += this.OnSecureStorageWriteStarted;
-                    this.stateManager.SecureStorageWriteCompleted += this.OnSecureStorageWriteCompleted;
-                    this.stateManager.SecureStorageWriteException += this.OnSecureStorageWriteException;
+                    this.stateManager.Value.RequestException += this.OnRequestException;
+                    this.stateManager.Value.SecureStorageReadStarted += this.OnSecureStorageReadStarted;
+                    this.stateManager.Value.SecureStorageReadCompleted += this.OnSecureStorageReadCompleted;
+                    this.stateManager.Value.SecureStorageReadException += this.OnSecureStorageReadException;
+                    this.stateManager.Value.SecureStorageWriteStarted += this.OnSecureStorageWriteStarted;
+                    this.stateManager.Value.SecureStorageWriteCompleted += this.OnSecureStorageWriteCompleted;
+                    this.stateManager.Value.SecureStorageWriteException += this.OnSecureStorageWriteException;
                 }
             }
         }
@@ -773,7 +772,7 @@ namespace Okta.Xamarin
         {
             this.OnSignInStarted();
             oidcClient = oidcClient ?? this.OidcClient;
-            this.OktaConfig = oidcClient.Config;
+            this.OktaConfig = oidcClient?.Config ?? GetService<IOktaConfig>();
             try
             {
                 this.StateManager = await oidcClient.SignInWithBrowserAsync();
@@ -817,7 +816,7 @@ namespace Okta.Xamarin
         {
             this.OnSignOutStarted();
             oidcClient = oidcClient ?? this.OidcClient;
-            this.StateManager = await oidcClient.SignOutOfOktaAsync(this.StateManager);
+            this.StateManager = await oidcClient?.SignOutOfOktaAsync(this.StateManager);
             this.OnSignOutCompleted();
         }
 

--- a/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
@@ -18,6 +18,7 @@ namespace Okta.Xamarin
     public class OktaContext
     {
         private static Lazy<OktaContext> current = new Lazy<OktaContext>(() => new OktaContext());
+        private static Lazy<TinyIoCContainer> container = new Lazy<TinyIoCContainer>(() => new TinyIoCContainer());
         private IOktaStateManager stateManager;
         private OAuthException oAuthException;
 
@@ -27,7 +28,6 @@ namespace Okta.Xamarin
         public OktaContext()
         {
             this.stateManager = new OktaStateManager();
-            this.IoCContainer = new TinyIoCContainer();
         }
 
         /// <summary>
@@ -347,7 +347,11 @@ namespace Okta.Xamarin
         /// <summary>
         /// Gets or sets the IoC containter.
         /// </summary>
-        public TinyIoCContainer IoCContainer { get; set; }
+        public TinyIoCContainer IoCContainer
+        {
+            get => container.Value;
+            set { container = new Lazy<TinyIoCContainer>(() => value); }
+        }
 
         /// <summary>
         /// Write the current state to secure storage.
@@ -465,7 +469,7 @@ namespace Okta.Xamarin
         public static T GetService<T>()
             where T : class
         {
-            return Current?.IoCContainer?.Resolve<T>();
+            return Current.IoCContainer.Resolve<T>();
         }
 
         /// <summary>
@@ -488,7 +492,7 @@ namespace Okta.Xamarin
             where TInterfaceType : class
             where TImplementationType : class, TInterfaceType
         {
-            Current?.IoCContainer?.Register<TInterfaceType, TImplementationType>();
+            Current.IoCContainer.Register<TInterfaceType, TImplementationType>();
         }
 
         /// <summary>
@@ -498,7 +502,7 @@ namespace Okta.Xamarin
         /// <param name="instance">Instance of RegisterType to register.</param>
         public static void RegisterServiceImplementation<TInterfaceType>(object instance)
         {
-            Current?.IoCContainer?.Register(typeof(TInterfaceType), instance);
+            Current.IoCContainer.Register(typeof(TInterfaceType), instance);
         }
 
         /// <summary>

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaLoggerShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaLoggerShould.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using FluentAssertions;
 using NSubstitute;
 using Okta.Xamarin.Services;
@@ -78,7 +79,7 @@ namespace Okta.Xamarin.Test
             testLogger.LogSecureStorageWriteStartedEvents((sender, args) => wasCalled = true);
             testLogger.LogSecureStorageWriteStartedEvents(); // use default event handler
             testOktaContext.RaiseSecureStorageWriteStartedEvent();
-
+            Thread.Sleep(300);
             wasCalled.Should().BeTrue();
             mockLogger.Received().Info(Arg.Any<string>(), Arg.Any<object[]>());
         }
@@ -358,6 +359,7 @@ namespace Okta.Xamarin.Test
             testLogger.LogGetUserStartedEvents((sender, args) => wasCalled = true);
             testLogger.LogGetUserStartedEvents(); // use default event handler
             testOktaContext.RaiseGetUserStartedEvent();
+            Thread.Sleep(100);
 
             wasCalled.Should().BeTrue();
             mockLogger.Received().Info(Arg.Any<string>(), Arg.Any<object[]>());

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/xunit.runner.json
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+    "parallelizeTestCollections": false
+}


### PR DESCRIPTION
- Lazy load IoCContainer to help prevent race conditions.
- Use async await for consistency
- Add delays where appropriate

Change to target `develop-v3.1.0` after release v3 is finalized.