### PR TITLE
OKTA-432598: properly capture api exception on renew

### DIFF
--- a/Okta.Xamarin/Okta.Xamarin.Android/OktaLogoutCallbackInterceptorActivity.cs
+++ b/Okta.Xamarin/Okta.Xamarin.Android/OktaLogoutCallbackInterceptorActivity.cs
@@ -14,7 +14,7 @@ namespace Okta.Xamarin.Android
 	[Activity(Label = "OktaLogoutCallbackInterceptorActivity", NoHistory = true, LaunchMode = LaunchMode.SingleInstance)]
 	public class OktaLogoutCallbackInterceptorActivity<TMain> : Activity
 	{
-		protected override async void OnCreate(Bundle savedInstanceState)
+		protected override void OnCreate(Bundle savedInstanceState)
 		{
 			base.OnCreate(savedInstanceState);
 			global::Android.Net.Uri uri_android = Intent.Data;

--- a/Okta.Xamarin/Okta.Xamarin/AssemblyInfo.cs
+++ b/Okta.Xamarin/Okta.Xamarin/AssemblyInfo.cs
@@ -1,3 +1,8 @@
+// <copyright file="AssemblyInfo.cs" company="Okta, Inc">
+// Copyright (c) 2020 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
 using Xamarin.Forms.Xaml;
 
 [assembly: XamlCompilation(XamlCompilationOptions.Compile)]

--- a/Okta.Xamarin/Okta.Xamarin/Base64UrlEncoder.cs
+++ b/Okta.Xamarin/Okta.Xamarin/Base64UrlEncoder.cs
@@ -1,4 +1,5 @@
-﻿//------------------------------------------------------------------------------
+﻿#pragma warning disable SA1633 // File should have header
+//------------------------------------------------------------------------------
 //
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
@@ -24,6 +25,7 @@
 // THE SOFTWARE.
 //
 //------------------------------------------------------------------------------
+#pragma warning restore SA1633 // File should have header
 
 using System;
 using System.Text;

--- a/Okta.Xamarin/Okta.Xamarin/DefaultOidcClient.cs
+++ b/Okta.Xamarin/Okta.Xamarin/DefaultOidcClient.cs
@@ -1,20 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Xamarin.Forms;
+﻿// <copyright file="DefaultOidcClient.cs" company="Okta, Inc">
+// Copyright (c) 2020 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
 
 namespace Okta.Xamarin
 {
-	public class DefaultOidcClient : OidcClient
-	{
-		protected override void CloseBrowser()
-		{
-			
-		}
+    public class DefaultOidcClient : OidcClient
+    {
+        protected override void CloseBrowser()
+        {
 
-		protected override void LaunchBrowser(string url)
-		{
-			
-		}
-	}
+        }
+
+        protected override void LaunchBrowser(string url)
+        {
+
+        }
+    }
 }

--- a/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OidcClient.cs
@@ -148,7 +148,7 @@ namespace Okta.Xamarin
         /// </summary>
         /// <param name="sessionToken">A valid session  token obtained via the <see cref="https://github.com/okta/okta-auth-dotnet">AuthN SDK</see></param>
         /// <returns>In case of successful authorization, this Task will return a valid <see cref="OktaStateManager"/>.  Clients are responsible for further storage and maintenance of the manager.</returns>
-        public async Task<IOktaStateManager> AuthenticateAsync(string sessionToken)
+        public Task<IOktaStateManager> AuthenticateAsync(string sessionToken)
         {
             throw new NotImplementedException("AuthN SDK is deprecated");
         }
@@ -438,9 +438,12 @@ namespace Okta.Xamarin
 
         private async Task ClearStateAsync()
         {
-            this.CloseBrowser();
-            loggingOutClientsByState.Remove(State);
-            currentTask.SetResult(new OktaStateManager());
+            await Task.Run(() =>
+            {
+                this.CloseBrowser();
+                loggingOutClientsByState.Remove(State);
+                currentTask.SetResult(new OktaStateManager());
+            });
         }
 
         /// <summary>

--- a/Okta.Xamarin/Okta.Xamarin/OktaApiException.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaApiException.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Okta.Xamarin
+{
+    /// <summary>
+    /// Represents an exception returned by the Okta Api.
+    /// </summary>
+    public class OktaApiException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OktaApiException"/> class.
+        /// </summary>
+        /// <param name="response">The error response.</param>
+        public OktaApiException(Response response)
+            : base($"{response.Error}: {response?.ErrorDescription}")
+        {
+            this.Response = response;
+        }
+
+        /// <summary>
+        /// Gets or sets the response.
+        /// </summary>
+        public Response Response { get; set; }
+    }
+}

--- a/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaContext.cs
@@ -991,14 +991,15 @@ namespace Okta.Xamarin
 
                 this.OnRenewStarted(refreshToken, refreshIdToken, authorizationServerId);
                 RenewResponse result = await this.StateManager.RenewAsync(refreshToken, refreshIdToken);
+                result.EnsureSuccess();
                 this.OnRenewCompleted(refreshToken, refreshIdToken, authorizationServerId, result);
 
                 return result;
             }
             catch (Exception ex)
             {
-                OnRenewException(ex);
-                return null;
+                this.OnRenewException(ex);
+                return new RenewResponse(ex);
             }
         }
 

--- a/Okta.Xamarin/Okta.Xamarin/RenewResponse.cs
+++ b/Okta.Xamarin/Okta.Xamarin/RenewResponse.cs
@@ -5,14 +5,26 @@
 
 using Newtonsoft.Json;
 using Okta.Xamarin.Models;
+using System;
 
 namespace Okta.Xamarin
 {
     /// <summary>
     /// Represents data returned in response to a renew request.
     /// </summary>
-    public class RenewResponse : Serializable
+    public class RenewResponse : Response
     {
+        public RenewResponse() { }
+
+        public RenewResponse(Exception ex)
+        {
+            if (ex != null)
+            {
+                Error = ex.GetType().Name;
+                ErrorDescription = ex.Message;
+            }
+        }
+
         /// <summary>
         /// Gets or sets the token type.
         /// </summary>

--- a/Okta.Xamarin/Okta.Xamarin/RequestExceptionEventArgs.cs
+++ b/Okta.Xamarin/Okta.Xamarin/RequestExceptionEventArgs.cs
@@ -24,7 +24,8 @@ namespace Okta.Xamarin
         /// <param name="headers">The headers.</param>
         /// <param name="authorizationServerId">The authorization server ID.</param>
         /// <param name="formUrlEncodedContent">The content.</param>
-        public RequestExceptionEventArgs(Exception ex, HttpMethod httpMethod, string path, Dictionary<string, string> headers, string authorizationServerId, KeyValuePair<string, string>[] formUrlEncodedContent)
+        /// <param name="responseBody">The body of the response if any.</param>
+        public RequestExceptionEventArgs(Exception ex, HttpMethod httpMethod, string path, Dictionary<string, string> headers, string authorizationServerId, KeyValuePair<string, string>[] formUrlEncodedContent, string responseBody = null)
         {
             this.Exception = ex;
             this.HttpMethod = httpMethod;
@@ -32,6 +33,7 @@ namespace Okta.Xamarin
             this.Headers = headers;
             this.AuthorizationServerId = authorizationServerId;
             this.FormUrlEncodedContent = formUrlEncodedContent;
+            this.ResponseBody = responseBody;
         }
 
         /// <summary>
@@ -63,5 +65,10 @@ namespace Okta.Xamarin
         /// Gets the form url encoded content.
         /// </summary>
         public KeyValuePair<string, string>[] FormUrlEncodedContent { get; }
+
+        /// <summary>
+        /// Gets the body of the response if any.
+        /// </summary>
+        public string ResponseBody { get; }
     }
 }

--- a/Okta.Xamarin/Okta.Xamarin/Response.cs
+++ b/Okta.Xamarin/Okta.Xamarin/Response.cs
@@ -1,0 +1,44 @@
+﻿// <copyright file="Response.cs" company="Okta, Inc">
+// Copyright (c) 2020 - present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using Newtonsoft.Json;
+using Okta.Xamarin.Models;
+
+namespace Okta.Xamarin
+{
+    /// <summary>
+    /// A base class for Okta API responses.
+    /// </summary>
+    public abstract class Response : Serializable
+    {
+        /// <summary>
+        /// Gets or sets the error if any.
+        /// </summary>
+        [JsonProperty("error")]
+        public string Error { get; set; }
+
+        /// <summary>
+        /// Gets or sets the error description if any.
+        /// </summary>
+        [JsonProperty("error_description")]
+        public string ErrorDescription { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether there is an error.
+        /// </summary>
+        public bool IsException => !string.IsNullOrEmpty(this.Error);
+
+        /// <summary>
+        /// Throws an OktaApiException exception if there is an error.
+        /// </summary>
+        public void EnsureSuccess()
+        {
+            if (this.IsException)
+            {
+                throw new OktaApiException(this);
+            }
+        }
+    }
+}

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaContextShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OktaContextShould.cs
@@ -72,7 +72,7 @@ namespace Okta.Xamarin.Test
             });
 
             await OktaContext.LoadStateAsync();
-            Thread.Sleep(100);
+            Thread.Sleep(300);
 
             completedEventWasRaised.Should().BeTrue();
             OktaContext.AccessToken.Should().BeEquivalentTo(testAccessToken); // Loading state should not overwrite existing access token with empty string
@@ -163,6 +163,7 @@ namespace Okta.Xamarin.Test
             OktaContext.AddSecureStorageReadCompletedListener((sender, args) => completedEventWasRaised = true);
 
             bool loaded = await OktaContext.LoadStateAsync();
+            Thread.Sleep(300);
 
             loaded.Should().BeTrue();
             startedEventWasRaised.Should().BeTrue();
@@ -284,7 +285,7 @@ namespace Okta.Xamarin.Test
 
             await OktaContext.Current.SignInAsync();
             await OktaContext.Current.SignOutAsync();
-            Thread.Sleep(100);
+            Thread.Sleep(300);
 
             Assert.True(signOutStartedEventRaised);
             Assert.True(signOutCompletedEventRaised);
@@ -353,7 +354,7 @@ namespace Okta.Xamarin.Test
             IOktaStateManager testStateManager = Substitute.For<IOktaStateManager>();
             testStateManager.RefreshToken.Returns("test refresh token");
             Task<RenewResponse> testRenewResponse = Task.FromResult(new RenewResponse());
-            testStateManager.RenewAsync().Returns(testRenewResponse);
+            testStateManager.RenewAsync(Arg.Any<string>(), Arg.Any<bool>()).Returns(testRenewResponse);
             OktaContext.Current.StateManager = testStateManager;
 
             bool? renewStartedRaised = false;
@@ -425,9 +426,7 @@ namespace Okta.Xamarin.Test
             Exception testException = new Exception("This is a test exception");
             IOktaStateManager mockStateManager = Substitute.For<IOktaStateManager>();
             mockStateManager.RefreshToken.Returns("test refresh token");
-            IOidcClient mockClient = Substitute.For<IOidcClient>();
-            mockClient.RenewAsync<RenewResponse>(Arg.Any<string>()).Returns(new RenewResponse());
-            mockStateManager.Client.Returns(mockClient);
+            mockStateManager.RenewAsync(Arg.Any<string>(), Arg.Any<bool>()).Returns(new RenewResponse());
             OktaContext.Current.StateManager = mockStateManager;
             OktaContext.AddRenewExceptionListener((sender, renewExceptionEventArgs) =>
             {


### PR DESCRIPTION
- Capture api error on renew with expired token.  Before this change the exception received by event subscribers was an object reference exception.
- deleted unused code
- addressed some warnings


https://user-images.githubusercontent.com/63638027/136427756-d9db0185-daa6-48ba-86e8-3c6e061f733c.mp4


