### PR TITLE
Ensures that CloseBrowser() is invoked on main thread

### DIFF
--- a/Okta.Xamarin/Okta.Xamarin.iOS/iOSOidcClient.cs
+++ b/Okta.Xamarin/Okta.Xamarin.iOS/iOSOidcClient.cs
@@ -7,6 +7,7 @@ using Foundation;
 using SafariServices;
 using System;
 using UIKit;
+using Xamarin.Forms;
 
 namespace Okta.Xamarin.iOS
 {

--- a/Okta.Xamarin/Okta.Xamarin.iOS/iOSOidcClient.cs
+++ b/Okta.Xamarin/Okta.Xamarin.iOS/iOSOidcClient.cs
@@ -57,9 +57,8 @@ namespace Okta.Xamarin.iOS
 		{
 			if (SafariViewController != null)
 			{
-				SafariViewController.DismissViewControllerAsync(false);
+				Device.BeginInvokeOnMainThread(() => SafariViewController.DismissViewControllerAsync(false));
 			}
-
 		}
 
 


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->


## Issue \#
<!-- Reference any existing issue(s) here. -->

Addresses #72 

## Code
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Unit test(s)
- [x] Implementation


## Current behavior
<!-- Describe what behavior is changing, if any. -->

Current behavior closes window but does not check for main UI thread when doing so. The exception is silently squashed because a background thread crashes

## Desired behavior
<!-- Describe what the desired behavior is. -->

`SignOutAsync()` closes the browser correctly when called

## Additional Context
<!-- Describe the motivation or the concrete use case. -->

