### PR TITLE
OKTA-444967: fix OktaStateManager.IsAuthenticated, add OktaStateManager.IsAccessTokenExpired

### DIFF
--- a/Okta.Xamarin/Okta.Xamarin/IOktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/IOktaStateManager.cs
@@ -78,9 +78,14 @@ namespace Okta.Xamarin
         string IdToken { get; }
 
         /// <summary>
-        /// Gets a value indicating whether or not there is a current non-expired <see cref="AccessToken"/>, which means that the user is authenticated.
+        /// Gets a value indicating whether or not there is an <see cref="AccessToken"/>.
         /// </summary>
         bool IsAuthenticated { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the value of the <see cref="Expires"/> property is in the past.
+        /// </summary>
+        bool IsAccessTokenExpired { get; }
 
         /// <summary>
         /// Gets the last response received from the API. Primarily for debugging.

--- a/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
+++ b/Okta.Xamarin/Okta.Xamarin/OktaStateManager.cs
@@ -118,8 +118,17 @@ namespace Okta.Xamarin
         {
             get
             {
-                return !string.IsNullOrEmpty(this.AccessToken) && // there is an access token
-                                (this.Expires == default(DateTimeOffset) || this.Expires > DateTime.UtcNow);    // and it's not yet expired
+                return !string.IsNullOrEmpty(this.AccessToken); // there is an access token
+            }
+        }
+
+        /// <inheritdoc/>
+        [JsonIgnore]
+        public bool IsAccessTokenExpired
+        {
+            get
+            {
+                return this.Expires == default(DateTimeOffset) || this.Expires < DateTime.UtcNow;
             }
         }
 

--- a/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClientShould.cs
+++ b/Okta.Xamarin/Tests/Okta.Xamarin.Test/OidcClientShould.cs
@@ -141,14 +141,18 @@ namespace Okta.Xamarin.Test
             OktaStateManager stateWithNoToken = new OktaStateManager(null, "test");
             Assert.False(stateWithNoToken.IsAuthenticated);
 
-            OktaStateManager stateWithTokenAndExpInPast = new OktaStateManager("test", "test", null, null, -100);
-            Assert.False(stateWithTokenAndExpInPast.IsAuthenticated);
-
             OktaStateManager stateWithNoExp = new OktaStateManager("test", "test");
             Assert.True(stateWithNoExp.IsAuthenticated);
+        }
+
+        [Fact]
+        public void CorrectlySetIsAccessTokenExpired()
+        {
+            OktaStateManager stateWithTokenAndExpInPast = new OktaStateManager("test", "test", null, null, -100);
+            Assert.True(stateWithTokenAndExpInPast.IsAccessTokenExpired);
 
             OktaStateManager stateWithExpInFuture = new OktaStateManager("test", "test", null, null, 100);
-            Assert.True(stateWithExpInFuture.IsAuthenticated);
+            Assert.False(stateWithExpInFuture.IsAccessTokenExpired);
         }
 
         [Fact]


### PR DESCRIPTION
- Change OktaStateManager.IsAuthenticated to only check for presence of access token.
- Add OktaStateManager.IsAccessTokenExpired

Fixes #74 